### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/components/Section/GettingStarted.vue
+++ b/docs/components/Section/GettingStarted.vue
@@ -70,7 +70,7 @@
       <span class="fn">dragAndDrop</span>({<br />
       <span class="indent">parent: <span class="var">parentRef</span></span
       >,<br />
-      <span class="indent">value: <span class="var">valueRef</span></span
+      <span class="indent">values: <span class="var">valueRef</span></span
       ><br />})
     </code>
   </SectionWrapper>


### PR DESCRIPTION
Fix typo in docs that could lead to some issues:
https://github.com/formkit/drag-and-drop/issues/78