### PR TITLE
docs: add missing homepage/repo in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,14 @@
   "keywords": [],
   "author": "Sasha Milenkovic <sasha@formkit.com>",
   "license": "MIT",
+  "homepage": "https://github.com/formkit/drag-and-drop",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/formkit/drag-and-drop.git"
+  },
+  "bugs": {
+    "url": "https://github.com/formkit/drag-and-drop/issues"
+  },
   "devDependencies": {
     "@formkit/drag-and-drop": "^0.2.3",
     "@playwright/test": "^1.42.1",


### PR DESCRIPTION
Same change was made in Tempo, the homepage & repo links were missing and doesn't show proper Renovate info when all these links are missing. This would also add missing links on the npm package website as well

See similar Tempo PR: https://github.com/formkit/tempo/pull/61