### PR TITLE
feat: allow disabling role assignment for draggable items

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -635,7 +635,11 @@ function deselect<T>(
   );
 
   for (const node of iterativeNodes) {
-    node.el.setAttribute("aria-selected", "false");
+    if (parent.data.config.noRoleAssigment) {
+      node.el.dataset.selected = 'false'
+    } else {
+      node.el.setAttribute("aria-selected", "false");
+    }
 
     const index = state.selectedState.nodes.findIndex((x) => x.el === node.el);
 
@@ -667,7 +671,11 @@ function setSelected<T>(
   state.pointerSelection = pointerdown;
 
   for (const node of selectedNodes) {
-    node.el.setAttribute("aria-selected", "true");
+    if(parent.data.config.noRoleAssigment){
+      node.el.dataset.selected = 'true'
+    }else {
+      node.el.setAttribute("aria-selected", "true");
+    }
 
     addNodeClass([node.el], parent.data.config.selectedClass, true);
   }
@@ -1117,9 +1125,13 @@ export function setupNode<T>(data: SetupNodeData<T>) {
     },
   });
 
-  data.node.el.setAttribute("role", "option");
 
-  data.node.el.setAttribute("aria-selected", "false");
+  if(config.noRoleAssigment){
+    data.node.el.dataset.selected = 'false'
+  }else {
+    data.node.el.setAttribute("role", "option");
+    data.node.el.setAttribute("aria-selected", "false");
+  }
 
   data.node.el.draggable = true;
 
@@ -1217,19 +1229,23 @@ function nodesMutated(mutationList: MutationRecord[]) {
   const parentEl = mutationList[0].target;
 
   if (!(parentEl instanceof HTMLElement)) return;
+  const parentData = parents.get(parentEl);
 
   const allSelectedAndActiveNodes = document.querySelectorAll(
-    `[aria-selected="true"]`
+      parentData?.config.noRoleAssigment ? `[data-selected="true"]` : `[aria-selected="true"]`
   );
 
-  const parentData = parents.get(parentEl);
 
   if (!parentData) return;
 
   for (let x = 0; x < allSelectedAndActiveNodes.length; x++) {
     const node = allSelectedAndActiveNodes[x];
 
-    node.setAttribute("aria-selected", "false");
+    if(parentData?.config.noRoleAssigment){
+        (node as HTMLElement).dataset.selected = 'false'
+    }else {
+      node.setAttribute("aria-selected", "false");
+    }
 
     removeClass([node], parentData.config.selectedClass);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,10 @@ export interface ParentConfig<T> {
    */
   disabled?: boolean;
   /**
+   * Prevents setting role attribute on nodes
+   */
+  noRoleAssigment?: boolean;
+  /**
    * A selector for the drag handle. Will search at any depth within the
    * draggable element.
    */


### PR DESCRIPTION
This PR introduces an option to disable automatic role assignment for draggable items, addressing [formkit#120](https://github.com/formkit/drag-and-drop/issues/120).

Instead of modifying the library to allow custom role settings, this change introduces a noRoleAssignment configuration option. By default, the library will continue assigning the appropriate roles (e.g., listbox and option). However, developers can now opt out of this behavior if they need to handle role assignment themselves—for instance, when working with Markdown-based content.

Key Changes:

- Added a `noRoleAssignment` option to the configuration.
- When enabled, the library will not set roles, giving developers full control.
- Default behavior remains unchanged to maintain backward compatibility.

This approach provides more flexibility while avoiding unnecessary complexity in the role assignment logic.