### PR TITLE
fix: import path for solid

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -72,6 +72,8 @@ const __dirname = dirname(__filename);
   await replaceImports("dist/vue/index.cjs");
   await replaceImports("dist/react/index.mjs");
   await replaceImports("dist/react/index.cjs");
+  await replaceImports("dist/solid/index.mjs");
+  await replaceImports("dist/solid/index.cjs");
 
   console.log("Rewriting package.json...");
 


### PR DESCRIPTION
currently solid js port dont work because of the import '../index' without extension
as I saw in build.ts there were no lines for adding an extension like in react and vue
