### PR TITLE
Use MaybeRef<T> for better Vue types

### DIFF
--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -1,15 +1,14 @@
-import type { Ref } from "vue";
+import type { MaybeRef, Ref } from "vue";
 import type { VueDragAndDropData, VueParentConfig } from "./types";
 import { dragAndDrop as initParent, isBrowser, tearDown } from "../index";
-import { onUnmounted, ref } from "vue";
+import { isRef, onUnmounted, ref, unref } from "vue";
 import { handleVueElements } from "./utils";
 export * from "./types";
 
 /**
  * Global store for parent els to values.
  */
-const parentValues: WeakMap<HTMLElement, Ref<Array<any>> | Array<any>> =
-  new WeakMap();
+const parentValues: WeakMap<HTMLElement, MaybeRef<Array<any>>> = new WeakMap();
 
 /**
  * Returns the values of the parent element.
@@ -27,7 +26,7 @@ function getValues(parent: HTMLElement): Array<any> {
     return [];
   }
 
-  return "value" in values ? values.value : values;
+  return unref(values);
 }
 
 /**
@@ -43,8 +42,7 @@ function setValues(newValues: Array<any>, parent: HTMLElement): void {
   const currentValues = parentValues.get(parent);
 
   // Only update reactive values. If static, let's not update.
-  if (currentValues && "value" in currentValues)
-    currentValues.value = newValues;
+  if (currentValues && isRef(currentValues)) currentValues.value = newValues;
   //else if (currentValues) parentValues.set(parent, newValues);
 }
 /**
@@ -110,7 +108,7 @@ export function useDragAndDrop<T>(
  */
 function handleParent<T>(
   config: Partial<VueParentConfig<T>>,
-  values: Ref<Array<T>> | Array<T>
+  values: MaybeRef<Array<T>>
 ) {
   return (parent: HTMLElement) => {
     parentValues.set(parent, values);

--- a/src/vue/types.ts
+++ b/src/vue/types.ts
@@ -1,11 +1,11 @@
-import type { Ref } from "vue";
+import type { MaybeRef, Ref } from "vue";
 import type { ParentConfig } from "../types";
 
 export type VueElement = HTMLElement | Ref<HTMLElement | undefined>;
 
 export interface VueDragAndDropData<T> extends VueParentConfig<T> {
   parent: HTMLElement | Ref<HTMLElement | undefined>;
-  values: Ref<Array<T>> | Array<T>;
+  values: MaybeRef<Array<T>>;
 }
 
 export type VueParentConfig<T> = Partial<ParentConfig<T>>;


### PR DESCRIPTION
This PR changes the type `Ref<Array<T>> | Array<T>` to `vue.MaybeRef<Array<T>>` .

A couple of Vue's reactivity utility methods were also swapped in (`isRef` and `unref`) to make the code slightly more idiomatic but this PR otherwise makes no functional changes.

Edit: I didn't realise until after I made this PR that dragAndDrop supports writable computed refs without MaybeRef, woops. Well it's a nice code clean-up anyway.