### PR TITLE
Add support for `useTemplateRef`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,7 @@ importers:
         specifier: ^3.11.1
         version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@18.19.76)(db0@0.2.4)(eslint@8.57.1)(ioredis@5.5.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.8)(terser@5.39.0)(typescript@5.7.3)(vite@6.1.1(@types/node@18.19.76)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))(yaml@2.7.0)
       vue:
-        specifier: ^3.4.21
+        specifier: ^3.5.0
         version: 3.5.13(typescript@5.7.3)
       vue-router:
         specifier: ^4.3.0

--- a/src/vue/types.ts
+++ b/src/vue/types.ts
@@ -1,10 +1,10 @@
 import type { Ref } from "vue";
 import type { ParentConfig } from "../types";
 
-export type VueElement = HTMLElement | Ref<HTMLElement | undefined>;
+export type VueElement = HTMLElement | Ref<HTMLElement | null | undefined>;
 
 export interface VueDragAndDropData<T> extends VueParentConfig<T> {
-  parent: HTMLElement | Ref<HTMLElement | undefined>;
+  parent: VueElement;
   values: Ref<Array<T>> | Array<T>;
 }
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@nuxtjs/tailwindcss": "^6.12.1",
     "nuxt": "^3.11.1",
-    "vue": "^3.4.21",
+    "vue": "^3.5.0",
     "vue-router": "^4.3.0",
     "@formkit/drag-and-drop": "workspace:*"
   },

--- a/tests/pages/accessibility/index.vue
+++ b/tests/pages/accessibility/index.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { dragAndDrop } from "../../../src/vue/index";
 
-const parent1: Ref<HTMLElement | undefined> = ref(undefined);
-const parent2: Ref<HTMLElement | undefined> = ref(undefined);
-const parent3: Ref<HTMLElement | undefined> = ref(undefined);
+const parent1 = useTemplateRef("parent1");
+const parent2 = useTemplateRef("parent2");
+const parent3 = useTemplateRef("parent3");
 
 const values1 = ref(["Apple", "Banana", "Orange"]);
 const values2 = ref(["Strawberry", "Blueberry", "Raspberry"]);

--- a/tests/pages/classes/index.vue
+++ b/tests/pages/classes/index.vue
@@ -6,7 +6,7 @@ const options = reactive({
   synthDraggingClasss: "draggingClass",
 });
 
-const parent: Ref<HTMLElement | undefined> = ref(undefined);
+const parent = useTemplateRef("parent");
 
 const values = ref(["Apple", "Banana", "Orange"]);
 


### PR DESCRIPTION
`useTemplateRef` returns a `HTMLElement | null` ref which has an incompatible type with the previous `HTMLElement | undefined`.

This PR adds `| null` to the allowed type of the parent ref to make it compatible. This is still backwards compatible with the old ref style too. As far I could tell, no functional changes needed to be made to support it.