### PR TITLE
Fix parent typing to use ShallowRef

### DIFF
--- a/src/vue/types.ts
+++ b/src/vue/types.ts
@@ -1,10 +1,10 @@
-import type { Ref } from "vue";
+import type { Ref, ShallowRef } from "vue";
 import type { ParentConfig } from "../types";
 
-export type VueElement = HTMLElement | Ref<HTMLElement | undefined>;
+export type VueElement = HTMLElement | Ref<HTMLElement | undefined | null>;
 
 export interface VueDragAndDropData<T> extends VueParentConfig<T> {
-  parent: HTMLElement | Ref<HTMLElement | undefined>;
+  parent: HTMLElement | ShallowRef<HTMLElement | null | undefined>;
   values: Ref<Array<T>> | Array<T>;
 }
 


### PR DESCRIPTION
This PR adjusts the typing of the parent property in VueDragAndDropData.
Previously, it was defined as:
```ts
HTMLElement | Ref<HTMLElement | undefined>
```
However, in practice we are passing a template ref, which in Vue 3 is typed as a ShallowRef.

**Problem**

When consuming this interface, TypeScript raises errors because the type does not align with how Vue template refs are defined:
```ts
Vue: Type 'ShallowRef<T | null>' is not assignable to type 
'HTMLElement | Ref<HTMLElement | undefined>'
  Type 'ShallowRef<T | null>' is not assignable to type 
  'Ref<HTMLElement | undefined>'
```

Currently, the workaround is to cast ShallowRef to Ref, but this is misleading and hides the actual usage pattern.

**Solution**

Update the type definition to reflect Vue’s behavior:

```ts
parent: HTMLElement | ShallowRef<HTMLElement | undefined>;
```

This makes the typing consistent with `useTemplateRef` and avoids unnecessary type assertions.

**Impact**

- Fixes TypeScript mismatches when passing template refs.
- No runtime changes — this is purely a type-level correction.