### PR TITLE
fix: support drag handles inside shadow DOM

### DIFF
--- a/playwright/tests/drag/draghandle-shadow.spec.ts
+++ b/playwright/tests/drag/draghandle-shadow.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect, Page } from "@playwright/test";
+import { drag } from "../../utils";
+
+let page: Page;
+
+test.beforeEach(async ({ browser }) => {
+  page = await browser.newPage();
+});
+
+test.describe("Native drag handle in shadow dom", async () => {
+  test("Should only drag when dragHandle selector exists in composed path", async () => {
+    await page.goto("http://localhost:3001/draghandle-shadow");
+    await new Promise((r) => setTimeout(r, 1000));
+
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      dragStart: true,
+    });
+    await expect(page.locator("#values_1")).toHaveText("Apple Banana Orange");
+
+    await drag(page, {
+      originEl: { id: "Apple_dragHandle", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      dragStart: true,
+    });
+    await expect(page.locator("#values_1")).toHaveText("Banana Apple Orange");
+  });
+});

--- a/playwright/tests/synthetic-drag/draghandle-shadow.spec.ts
+++ b/playwright/tests/synthetic-drag/draghandle-shadow.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect, Page } from "@playwright/test";
+import { syntheticDrag } from "../../utils";
+
+let page: Page;
+
+test.beforeEach(async ({ browser }) => {
+  page = await browser.newPage();
+});
+
+test.describe("Synthetic drag handle in shadow dom", async () => {
+  test("Should only drag when dragHandle selector exists in composed path", async () => {
+    await page.goto("http://localhost:3001/draghandle-shadow");
+    await new Promise((r) => setTimeout(r, 1000));
+
+    await syntheticDrag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      dragStart: true,
+    });
+    await expect(page.locator("#values_1")).toHaveText("Apple Banana Orange");
+
+    await syntheticDrag(page, {
+      originEl: { id: "Apple_dragHandle", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      dragStart: true,
+    });
+    await expect(page.locator("#values_1")).toHaveText("Banana Apple Orange");
+  });
+});

--- a/playwright/utils.ts
+++ b/playwright/utils.ts
@@ -22,9 +22,33 @@ export async function drag(page: Page, data: DragDropData): Promise<void> {
   // Shouldn't need to do this, but leaving it for now 🤷‍♂️
   await new Promise((resolve) => setTimeout(resolve, 25));
   return page.evaluate(async (data) => {
-    const originElement = document.getElementById(data.originEl.id);
+    const findElementById = (id: string): Element | null => {
+      const queue: Array<Document | ShadowRoot> = [document];
 
-    const destinationElement = document.getElementById(data.destinationEl.id);
+      while (queue.length) {
+        const root = queue.shift();
+
+        if (!root) continue;
+
+        const match = root.querySelector(`#${CSS.escape(id)}`);
+
+        if (match) return match;
+
+        const hosts = root.querySelectorAll("*");
+
+        for (const host of hosts) {
+          if (host instanceof HTMLElement && host.shadowRoot) {
+            queue.push(host.shadowRoot);
+          }
+        }
+      }
+
+      return null;
+    };
+
+    const originElement = findElementById(data.originEl.id);
+
+    const destinationElement = findElementById(data.destinationEl.id);
 
     if (!originElement || !destinationElement) return;
 
@@ -38,6 +62,7 @@ export async function drag(page: Page, data: DragDropData): Promise<void> {
       return {
         bubbles: true,
         cancelable: true,
+        composed: true,
         clientX: x,
         clientY: y,
         dataTransfer,
@@ -100,8 +125,32 @@ export async function syntheticDrag(
   // Shouldn't need to do this, but leaving it for now 🤷‍♂️
   await new Promise((resolve) => setTimeout(resolve, 25));
   return page.evaluate(async (data) => {
-    const originElement = document.getElementById(data.originEl.id);
-    const destinationElement = document.getElementById(data.destinationEl.id);
+    const findElementById = (id: string): Element | null => {
+      const queue: Array<Document | ShadowRoot> = [document];
+
+      while (queue.length) {
+        const root = queue.shift();
+
+        if (!root) continue;
+
+        const match = root.querySelector(`#${CSS.escape(id)}`);
+
+        if (match) return match;
+
+        const hosts = root.querySelectorAll("*");
+
+        for (const host of hosts) {
+          if (host instanceof HTMLElement && host.shadowRoot) {
+            queue.push(host.shadowRoot);
+          }
+        }
+      }
+
+      return null;
+    };
+
+    const originElement = findElementById(data.originEl.id);
+    const destinationElement = findElementById(data.destinationEl.id);
 
     if (!originElement || !destinationElement) return;
 
@@ -137,6 +186,7 @@ export async function syntheticDrag(
       return {
         bubbles: true,
         cancelable: true,
+        composed: true,
         clientX: x,
         clientY: y,
         screenX: x,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1362,8 +1362,7 @@ export function handleDragstart<T>(
     !config.nativeDrag ||
     !validateDragstart(data) ||
     !validateDragHandle({
-      x: data.e.clientX,
-      y: data.e.clientY,
+      event: data.e,
       node: data.targetData.node,
       config,
     })
@@ -1417,8 +1416,7 @@ export function handleNodePointerdown<T>(
 
   if (
     !validateDragHandle({
-      x: data.e.clientX,
-      y: data.e.clientY,
+      event: data.e,
       node: data.targetData.node,
       config: data.targetData.parent.data.config,
     })
@@ -1683,13 +1681,11 @@ export function initDrag<T>(
 }
 
 export function validateDragHandle<T>({
-  x,
-  y,
+  event,
   node,
   config,
 }: {
-  x: number;
-  y: number;
+  event: PointerEvent | DragEvent;
   node: NodeRecord<T>;
   config: ParentConfig<T>;
 }): boolean {
@@ -1697,16 +1693,19 @@ export function validateDragHandle<T>({
 
   if (!config.dragHandle) return true;
 
-  const dragHandles = node.el.querySelectorAll(config.dragHandle);
+  const dragPath = event.composedPath?.() ?? [];
 
-  if (!dragHandles) return false;
+  const draggableNodePathIndex = dragPath.indexOf(node.el);
 
-  const elFromPoint = config.root.elementFromPoint(x, y);
+  if (draggableNodePathIndex === -1) return false;
 
-  if (!elFromPoint) return false;
+  for (let x = 0; x < draggableNodePathIndex; x++) {
+    const pathNode = dragPath[x];
 
-  for (const handle of Array.from(dragHandles))
-    if (elFromPoint === handle || handle.contains(elFromPoint)) return true;
+    if (!(pathNode instanceof Element)) continue;
+
+    if (pathNode.matches(config.dragHandle)) return true;
+  }
 
   return false;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export interface ParentConfig<T> {
     targetParentData: ParentRecord<T>,
     initialParentData: ParentRecord<T>,
     currentParentData: ParentRecord<T>,
-    state: BaseDragState<T>
+    state: BaseDragState<T>,
   ) => boolean;
 
   /**
@@ -55,7 +55,7 @@ export interface ParentConfig<T> {
    */
   dragImage?: (
     data: NodeDragEventData<T>,
-    draggedNodes: Array<NodeRecord<T>>
+    draggedNodes: Array<NodeRecord<T>>,
   ) => HTMLElement;
   /**
    * A flag to disable dragability of all nodes in the parent.
@@ -63,7 +63,7 @@ export interface ParentConfig<T> {
   disabled?: boolean;
   /**
    * A selector for the drag handle. Will search at any depth within the
-   * draggable element.
+   * draggable element including nested shadow roots.
    */
   dragHandle?: string;
   /**
@@ -96,7 +96,7 @@ export interface ParentConfig<T> {
     node: NodeRecord<T>,
     nodes: Array<NodeRecord<T>>,
     config: ParentConfig<T>,
-    isSynthDrag?: boolean
+    isSynthDrag?: boolean,
   ) => void;
   // When drag starts, this will be applied to the dragged node(s) (not their
   // representations being dragged) on dragstart. This will remain on the nodes
@@ -125,7 +125,7 @@ export interface ParentConfig<T> {
   group?: string;
   handleParentFocus: (
     data: ParentEventData<T>,
-    state: BaseDragState<T>
+    state: BaseDragState<T>,
   ) => void;
   handleNodeKeydown: (data: NodeEventData<T>, state: DragState<T>) => void;
 
@@ -141,18 +141,18 @@ export interface ParentConfig<T> {
   handleNodeDrop: (data: NodeDragEventData<T>, state: DragState<T>) => void;
   handleNodePointerup: (
     data: NodePointerEventData<T>,
-    state: DragState<T>
+    state: DragState<T>,
   ) => void;
   handleParentScroll: (
     data: ParentEventData<T>,
-    state: DragState<T> | BaseDragState<T> | SynthDragState<T>
+    state: DragState<T> | BaseDragState<T> | SynthDragState<T>,
   ) => void;
   /**
    * Function that is called when a dragenter event is triggered on the node.
    */
   handleNodeDragenter: (
     data: NodeDragEventData<T>,
-    state: DragState<T>
+    state: DragState<T>,
   ) => void;
   handleNodeBlur: (data: NodeEventData<T>, state: DragState<T>) => void;
   handleNodeFocus: (data: NodeEventData<T>, state: DragState<T>) => void;
@@ -161,14 +161,14 @@ export interface ParentConfig<T> {
    */
   handleNodeDragleave: (
     data: NodeDragEventData<T>,
-    state: DragState<T>
+    state: DragState<T>,
   ) => void;
   /**
    * Function that is called when a dragover event is triggered on the parent.
    */
   handleParentDragover: (
     data: ParentDragEventData<T>,
-    state: DragState<T>
+    state: DragState<T>,
   ) => void;
   /**
    * Drop event on parent
@@ -180,14 +180,14 @@ export interface ParentConfig<T> {
   handleNodeDragover: (data: NodeDragEventData<T>, state: DragState<T>) => void;
   handlePointercancel: (
     data: NodeDragEventData<T> | NodePointerEventData<T>,
-    state: DragState<T> | SynthDragState<T> | BaseDragState<T>
+    state: DragState<T> | SynthDragState<T> | BaseDragState<T>,
   ) => void;
   /*
    * Function that is called when a pointerdown is triggered on node.
    */
   handleNodePointerdown: (
     data: NodePointerEventData<T>,
-    state: DragState<T>
+    state: DragState<T>,
   ) => void;
   /**
    * Function that is called when a node that is being moved by touchmove event
@@ -195,7 +195,7 @@ export interface ParentConfig<T> {
    */
   handleNodePointerover: (
     data: PointeroverNodeEvent<T>,
-    state: SynthDragState<T>
+    state: SynthDragState<T>,
   ) => void;
   /**
    * Function that is called when a node that is being moved by touchmove event
@@ -203,7 +203,7 @@ export interface ParentConfig<T> {
    */
   handleParentPointerover: (
     e: PointeroverParentEvent<T>,
-    state: SynthDragState<T>
+    state: SynthDragState<T>,
   ) => void;
   /**
    * Config option for insert plugin.
@@ -307,7 +307,7 @@ export interface ParentConfig<T> {
     node: NodeRecord<T>,
     parent: ParentRecord<T>,
     e: PointerEvent,
-    draggedNodes: Array<NodeRecord<T>>
+    draggedNodes: Array<NodeRecord<T>>,
   ) => {
     dragImage: HTMLElement;
     offsetX?: number;
@@ -981,19 +981,19 @@ export interface DropSwapConfig<T> {
   shouldSwap?: (data: ShouldSwapData<T>) => boolean;
   handleNodeDragover?: (
     data: NodeDragEventData<T>,
-    state: DragState<T>
+    state: DragState<T>,
   ) => void;
   handleParentDragover?: (
     data: ParentDragEventData<T>,
-    state: DragState<T>
+    state: DragState<T>,
   ) => void;
   handleParentPointerover?: (
     e: PointeroverParentEvent<T>,
-    state: DragState<T>
+    state: DragState<T>,
   ) => void;
   handleNodePointerover?: (
     data: PointeroverNodeEvent<T>,
-    state: SynthDragState<T>
+    state: SynthDragState<T>,
   ) => void;
 }
 
@@ -1009,16 +1009,16 @@ export interface InsertConfig<T> {
   insertEvent?: (data: InsertEvent<T>) => void;
   handleNodeDragover?: (
     data: NodeDragEventData<T>,
-    state: DragState<T>
+    state: DragState<T>,
   ) => void;
   handleParentDragover?: (
     data: ParentDragEventData<T>,
-    state: DragState<T>
+    state: DragState<T>,
   ) => void;
   handleParentPointerover?: (data: PointeroverParentEvent<T>) => void;
   handleNodePointerover?: (data: PointeroverNodeEvent<T>) => void;
   handleEnd?: (
-    state: BaseDragState<T> | DragState<T> | SynthDragState<T>
+    state: BaseDragState<T> | DragState<T> | SynthDragState<T>,
   ) => void;
   dynamicValues?: (data: DynamicValuesData<T>) => Array<T>;
 }

--- a/tests/pages/draghandle-shadow/index.vue
+++ b/tests/pages/draghandle-shadow/index.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { useDragAndDrop } from "../../../src/vue/index";
+
+if (typeof window !== "undefined" && !customElements.get("shadow-drag-handle")) {
+  class ShadowDragHandle extends HTMLElement {
+    connectedCallback() {
+      if (this.shadowRoot) return;
+
+      const itemId = this.getAttribute("item-id") ?? "";
+
+      const root = this.attachShadow({ mode: "open" });
+
+      root.innerHTML = `
+        <style>
+          .dragHandle {
+            cursor: grab;
+            color: #475569;
+            border: 1px solid #cbd5e1;
+            background: #f8fafc;
+            border-radius: 4px;
+            padding: 2px 6px;
+            line-height: 1;
+            font-size: 12px;
+          }
+        </style>
+        <button id="${itemId}_dragHandle" class="dragHandle" type="button">::</button>
+      `;
+    }
+  }
+
+  customElements.define("shadow-drag-handle", ShadowDragHandle);
+}
+
+const [parent1, values1] = useDragAndDrop(["Apple", "Banana", "Orange"], {
+  dragHandle: ".dragHandle",
+  draggable: (el) => el.tagName === "LI",
+});
+</script>
+
+<template>
+  <h1>Shadow Drag Handle</h1>
+  <ul ref="parent1" class="list">
+    <li v-for="value in values1" :id="value" :key="value" class="item">
+      <shadow-drag-handle :item-id="value" />
+      <span class="label">{{ value }}</span>
+    </li>
+    <span id="values_1">{{ values1.map((x) => x).join(" ") }}</span>
+  </ul>
+</template>
+
+<style scoped>
+.list {
+  list-style: none;
+  padding: 0;
+}
+
+.item {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+}
+
+.label {
+  color: #334155;
+}
+</style>


### PR DESCRIPTION
## Summary
- update drag handle validation to use the event composed path instead of point-based DOM lookup
- allow drag handle matching to work for handles rendered inside nested shadow roots
- update Playwright drag helpers so native and synthetic drag tests can target shadow-root elements
- add draghandle-shadow test coverage and a dedicated test page for the scenario

## Why
Drag handles rendered inside shadow DOM were not recognized reliably because validation only queried light-DOM descendants from the draggable node. This change makes drag handle detection event-aware and shadow-DOM compatible.

## Testing
- add native drag Playwright coverage for drag handles inside shadow DOM
- add synthetic drag Playwright coverage for drag handles inside shadow DOM
- verify dragging from the item body does not reorder
- verify dragging from the shadow-root handle reorders items as expected

#170