### PR TITLE
feat(drag-and-drop): add shadowDragHandle support for Shadow DOM handle matching

### DIFF
--- a/playwright/tests/drag/draghandle.spec.ts
+++ b/playwright/tests/drag/draghandle.spec.ts
@@ -27,4 +27,27 @@ test.describe("Native drag with drag handles", async () => {
     });
     await expect(page.locator("#values_1")).toHaveText("Banana Apple Orange");
   });
+
+  test("Native drag with shadowDragHandle. Should only drag when using handle inside shadow DOM", async () => {
+    await page.goto("http://localhost:3001/draghandle");
+    await new Promise((r) => setTimeout(r, 1000));
+
+    await drag(page, {
+      originEl: { id: "ShadowApple", position: "center" },
+      destinationEl: { id: "ShadowBanana", position: "center" },
+      dragStart: true,
+    });
+    await expect(page.locator("#values_shadow")).toHaveText(
+      "ShadowApple ShadowBanana ShadowOrange"
+    );
+
+    await drag(page, {
+      originEl: { id: "ShadowApple_shadowDragHandle", position: "center" },
+      destinationEl: { id: "ShadowBanana", position: "center" },
+      dragStart: true,
+    });
+    await expect(page.locator("#values_shadow")).toHaveText(
+      "ShadowBanana ShadowApple ShadowOrange"
+    );
+  });
 });

--- a/playwright/tests/synthetic-drag/draghandle.spec.ts
+++ b/playwright/tests/synthetic-drag/draghandle.spec.ts
@@ -27,4 +27,27 @@ test.describe("Synth Drag handles", async () => {
     });
     await expect(page.locator("#values_1")).toHaveText("Banana Apple Orange");
   });
+
+  test("Test #2: shadowDragHandle should match a handle inside shadow DOM.", async () => {
+    await page.goto("http://localhost:3001/draghandle");
+    await new Promise((r) => setTimeout(r, 1000));
+
+    await syntheticDrag(page, {
+      originEl: { id: "ShadowApple", position: "center" },
+      destinationEl: { id: "ShadowBanana", position: "center" },
+      dragStart: true,
+    });
+    await expect(page.locator("#values_shadow")).toHaveText(
+      "ShadowApple ShadowBanana ShadowOrange"
+    );
+
+    await syntheticDrag(page, {
+      originEl: { id: "ShadowApple_shadowDragHandle", position: "center" },
+      destinationEl: { id: "ShadowBanana", position: "center" },
+      dragStart: true,
+    });
+    await expect(page.locator("#values_shadow")).toHaveText(
+      "ShadowBanana ShadowApple ShadowOrange"
+    );
+  });
 });

--- a/playwright/utils.ts
+++ b/playwright/utils.ts
@@ -22,9 +22,39 @@ export async function drag(page: Page, data: DragDropData): Promise<void> {
   // Shouldn't need to do this, but leaving it for now 🤷‍♂️
   await new Promise((resolve) => setTimeout(resolve, 25));
   return page.evaluate(async (data) => {
-    const originElement = document.getElementById(data.originEl.id);
+    const findElementById = (id: string): HTMLElement | null => {
+      const direct = document.getElementById(id);
 
-    const destinationElement = document.getElementById(data.destinationEl.id);
+      if (direct) return direct;
+
+      const queue: Array<Element | ShadowRoot> = [document.documentElement];
+
+      while (queue.length) {
+        const current = queue.shift();
+
+        if (!current) continue;
+
+        const root = current instanceof ShadowRoot ? current : current.shadowRoot;
+
+        if (root) {
+          const fromShadow = root.getElementById(id);
+
+          if (fromShadow) return fromShadow as HTMLElement;
+
+          queue.push(...Array.from(root.children));
+        }
+
+        if (current instanceof Element) {
+          queue.push(...Array.from(current.children));
+        }
+      }
+
+      return null;
+    };
+
+    const originElement = findElementById(data.originEl.id);
+
+    const destinationElement = findElementById(data.destinationEl.id);
 
     if (!originElement || !destinationElement) return;
 
@@ -37,6 +67,7 @@ export async function drag(page: Page, data: DragDropData): Promise<void> {
 
       return {
         bubbles: true,
+        composed: true,
         cancelable: true,
         clientX: x,
         clientY: y,
@@ -100,8 +131,38 @@ export async function syntheticDrag(
   // Shouldn't need to do this, but leaving it for now 🤷‍♂️
   await new Promise((resolve) => setTimeout(resolve, 25));
   return page.evaluate(async (data) => {
-    const originElement = document.getElementById(data.originEl.id);
-    const destinationElement = document.getElementById(data.destinationEl.id);
+    const findElementById = (id: string): HTMLElement | null => {
+      const direct = document.getElementById(id);
+
+      if (direct) return direct;
+
+      const queue: Array<Element | ShadowRoot> = [document.documentElement];
+
+      while (queue.length) {
+        const current = queue.shift();
+
+        if (!current) continue;
+
+        const root = current instanceof ShadowRoot ? current : current.shadowRoot;
+
+        if (root) {
+          const fromShadow = root.getElementById(id);
+
+          if (fromShadow) return fromShadow as HTMLElement;
+
+          queue.push(...Array.from(root.children));
+        }
+
+        if (current instanceof Element) {
+          queue.push(...Array.from(current.children));
+        }
+      }
+
+      return null;
+    };
+
+    const originElement = findElementById(data.originEl.id);
+    const destinationElement = findElementById(data.destinationEl.id);
 
     if (!originElement || !destinationElement) return;
 
@@ -136,6 +197,7 @@ export async function syntheticDrag(
 
       return {
         bubbles: true,
+        composed: true,
         cancelable: true,
         clientX: x,
         clientY: y,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1364,6 +1364,7 @@ export function handleDragstart<T>(
     !validateDragHandle({
       x: data.e.clientX,
       y: data.e.clientY,
+      e: data.e,
       node: data.targetData.node,
       config,
     })
@@ -1419,6 +1420,7 @@ export function handleNodePointerdown<T>(
     !validateDragHandle({
       x: data.e.clientX,
       y: data.e.clientY,
+      e: data.e,
       node: data.targetData.node,
       config: data.targetData.parent.data.config,
     })
@@ -1685,15 +1687,29 @@ export function initDrag<T>(
 export function validateDragHandle<T>({
   x,
   y,
+  e,
   node,
   config,
 }: {
   x: number;
   y: number;
+  e: PointerEvent | DragEvent;
   node: NodeRecord<T>;
   config: ParentConfig<T>;
 }): boolean {
   if (config.externalDragHandle) return false;
+
+  if (config.shadowDragHandle) {
+    const path = e.composedPath();
+
+    for (const target of path) {
+      if (!(target instanceof Element)) continue;
+
+      if (target.matches(config.shadowDragHandle)) return true;
+    }
+
+    return false;
+  }
 
   if (!config.dragHandle) return true;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,11 @@ export interface ParentConfig<T> {
    */
   dragHandle?: string;
   /**
+   * A selector for drag handles inside Shadow DOM. Matching is performed
+   * against the event composedPath instead of querySelector.
+   */
+  shadowDragHandle?: string;
+  /**
    * External drag handle
    */
   externalDragHandle?: {

--- a/tests/pages/dragHandle/index.vue
+++ b/tests/pages/dragHandle/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { onMounted } from "vue";
 import { useDragAndDrop } from "../../../src/vue/index";
 
 const [parent1, values1] = useDragAndDrop(["Apple", "Banana", "Orange"], {
@@ -37,6 +38,52 @@ const [parent3, values3] = useDragAndDrop(
 function click() {
   console.log("click");
 }
+
+const [shadowParent, shadowValues] = useDragAndDrop(
+  ["ShadowApple", "ShadowBanana", "ShadowOrange"],
+  {
+    draggable: (el) => {
+      return el.tagName === "LI";
+    },
+    dragHandle: ".does-not-exist",
+    shadowDragHandle: ".dragHandle",
+  }
+);
+
+onMounted(() => {
+  const createShadowHandle = (host: HTMLElement, itemId: string) => {
+    const root = host.shadowRoot ?? host.attachShadow({ mode: "open" });
+
+    root.innerHTML = `
+      <style>
+        .dragHandle {
+          cursor: grab;
+          color: #94a3b8;
+          display: inline-flex;
+          align-items: center;
+          width: 24px;
+          height: 24px;
+        }
+      </style>
+      <span id="${itemId}_shadowDragHandle" class="dragHandle" aria-label="shadow drag handle">
+        <svg viewBox="0 0 24 24" width="24" height="24">
+          <path
+            fill="currentColor"
+            d="M9,3H11V5H9V3M13,3H15V5H13V3M9,7H11V9H9V7M13,7H15V9H13V7M9,11H11V13H9V11M13,11H15V13H13V11M9,15H11V17H9V15M13,15H15V17H13V15M9,19H11V21H9V19M13,19H15V21H13V19Z"
+          />
+        </svg>
+      </span>
+    `;
+  };
+
+  for (const value of shadowValues.value) {
+    const host = document.getElementById(`${value}_shadowHost`);
+
+    if (!host) continue;
+
+    createShadowHandle(host, value);
+  }
+});
 </script>
 
 <template>
@@ -102,6 +149,20 @@ function click() {
         </li>
         <span id="values_3" class="values-display">
           {{ values3.map((x) => x).join(" ") }}
+        </span>
+      </ul>
+    </div>
+    <div class="list-container">
+      <h2>Shadow Handle List</h2>
+      <ul id="shadow_list" ref="shadowParent" class="list">
+        <li v-for="value in shadowValues" :id="value" :key="value" class="item">
+          <div class="item-content">
+            <span :id="value + '_shadowHost'" class="shadow-host"></span>
+            <span class="item-text">{{ value }}</span>
+          </div>
+        </li>
+        <span id="values_shadow" class="values-display">
+          {{ shadowValues.map((x) => x).join(" ") }}
         </span>
       </ul>
     </div>


### PR DESCRIPTION
### Summary

This PR adds support for a new config option, shadowDragHandle, to enable drag handle matching inside Shadow DOM using event composedPath traversal.

### What Changed
- Added shadowDragHandle to parent configuration types.
- Updated drag handle validation to:
  - Prefer shadowDragHandle when provided.
  - Match selectors against the event composedPath.
  - Skip querySelector-based matching in that mode.
- Kept existing behavior for dragHandle unchanged when shadowDragHandle is not set.
- Added end-to-end test coverage for:
  - Native drag behavior with shadow-based handles.
  - Synthetic drag behavior with shadow-based handles.
  - Negative path where dragging from non-handle areas is rejected.
  - Precedence path showing shadowDragHandle is used instead of dragHandle selector matching.
- Updated test utilities to reliably target elements in open Shadow roots and dispatch composed events where needed.

### Why
Selector matching via querySelector cannot traverse into Shadow DOM internals. Matching with composedPath enables reliable drag-handle validation for web components and encapsulated UI.

### Testing Notes
- Added targeted Playwright scenarios for both desktop native drag and mobile synthetic drag flows.

#170