### PR TITLE
fix: guard validateTransfer against undefined target/current parent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2370,6 +2370,12 @@ export function validateTransfer<T>({
   draggedNodes: Array<NodeRecord<T>>;
   state: BaseDragState<T>;
 }) {
+  // A `dragover` can fire when there is no valid target/current parent (e.g.
+  // hovering the source list of a transfer setup). Without this guard the
+  // first `targetParent.el` access throws an uncaught TypeError and breaks the
+  // drag interaction. No valid parent means the transfer is simply not valid.
+  if (!targetParent || !currentParent) return false;
+
   if (targetParent.el === currentParent.el) return false;
 
   const targetConfig = targetParent.data.config;


### PR DESCRIPTION
### Problem

`validateTransfer` dereferences `targetParent.el` on its first line without a null check ([`src/index.ts#L2373`](https://github.com/formkit/drag-and-drop/blob/main/src/index.ts#L2373)). During a `dragover` it can be invoked with `targetParent` (or `currentParent`) `undefined`, throwing an uncaught `TypeError: Cannot read properties of undefined (reading 'el')` and breaking the drag interaction.

We hit this in production via the transfer-list pattern (it is what FormKit Pro's `transferlist` input uses under the hood) when dragging over the source list. Seen on Chrome desktop and Chrome Mobile iOS. The `dragover` listener is unhandled, so it surfaces as a hard error.

Stack trace (from `0.5.3`, the current release):

```
TypeError: Cannot read properties of undefined (reading 'el')
  at validateTransfer (index.mjs)
  at transfer          (index.mjs)
  at handleParentDragover (index.mjs)
```

### Fix

Add a defensive guard before the first dereference. When there is no valid target/current parent the transfer simply is not valid, so returning `false` is the correct behavior and removes the crash without changing any valid-transfer logic.

```ts
if (!targetParent || !currentParent) return false;
```

Happy to adjust or add a Playwright case if you'd like one.