### PR TITLE
fix(vue): accept null template refs so useTemplateRef type-checks

### DIFF
--- a/src/vue/types.ts
+++ b/src/vue/types.ts
@@ -1,10 +1,10 @@
 import type { MaybeRef, Ref } from "vue";
 import type { ParentConfig } from "../types";
 
-export type VueElement = HTMLElement | Ref<HTMLElement | undefined>;
+export type VueElement = HTMLElement | Ref<HTMLElement | null | undefined>;
 
 export interface VueDragAndDropData<T> extends VueParentConfig<T> {
-  parent: HTMLElement | Ref<HTMLElement | undefined>;
+  parent: VueElement;
   values: MaybeRef<Array<T>>;
 }
 

--- a/tests-frameworks/vue/components/Test1.vue
+++ b/tests-frameworks/vue/components/Test1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, useTemplateRef } from "vue";
 import { dragAndDrop } from "../../../src/vue/index";
 
 const props = defineProps<{
@@ -18,7 +18,7 @@ const values = ref([
   },
 ]);
 
-const parent = ref();
+const parent = useTemplateRef<HTMLElement>("parent");
 
 dragAndDrop({
   parent,


### PR DESCRIPTION
Reimplements #147 by @jf908 against `release/0.6.0` (the original PR's test-page changes target files that no longer exist, and its lockfile hunk conflicts).

## What
- `VueElement` now accepts `Ref<HTMLElement | null | undefined>`, so Vue 3.5's `useTemplateRef()` (which returns `Ref<HTMLElement | null>`) type-checks when passed as `parent`.
- `VueDragAndDropData.parent` reuses `VueElement` instead of duplicating the union.
- Converted `tests-frameworks/vue/components/Test1.vue` to `useTemplateRef` so the existing Vue framework e2e tests exercise the new path.

## Why it's safe
`handleVueElements` already watches the ref and ignores falsy values until a real element shows up (`if (!newEl) return`), so this is purely a type-level widening — no runtime change.

## Testing
- `tsc --noEmit` clean
- Framework e2e suite (Vue/React/Solid/Marko): 9/9 passed on Chrome

Fixes #147's intent; credits the original author via co-author trailer.