### PR TITLE
fix: restore original z-index after drag ends

### DIFF
--- a/playwright/tests/drag/zindex.spec.ts
+++ b/playwright/tests/drag/zindex.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect, Page } from "@playwright/test";
+import { drag } from "../../utils";
+
+let page: Page;
+
+test.beforeEach(async ({ browser }) => {
+  page = await browser.newPage();
+});
+
+test.describe("Dragged node z-index", async () => {
+  test("inline z-index is restored after drag ends (#154)", async () => {
+    await page.goto("http://localhost:3001/sort");
+    await new Promise((r) => setTimeout(r, 1000));
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#sort_values")).toHaveText(
+      "Banana Apple Orange"
+    );
+    const zIndex = await page.evaluate(
+      () => document.getElementById("Apple")?.style.zIndex
+    );
+    expect(zIndex).toBe("");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1614,6 +1614,10 @@ export function initDrag<T>(
       dragImage = config.dragImage(data, draggedNodes);
     } else {
       if (!config.multiDrag || draggedNodes.length === 1) {
+        // Capture the original inline z-index before elevating the node so
+        // handleEnd restores the user's value instead of the temporary 9999.
+        dragState.originalZIndex = data.targetData.node.el.style.zIndex;
+
         data.targetData.node.el.style.zIndex = "9999";
         data.targetData.node.el.style.boxSizing = "border-box";
 
@@ -1622,8 +1626,6 @@ export function initDrag<T>(
           data.e.offsetX,
           data.e.offsetY
         );
-
-        dragState.originalZIndex = data.targetData.node.el.style.zIndex;
 
         return dragState;
       } else {


### PR DESCRIPTION
Lands #154 by @DanielASMPT against `release/0.6.0`, taking only the `src/index.ts` change (the original PR also committed rebuilt `dist/` artifacts, which we don't keep in PRs).

## Bug
`initDrag` set the dragged node's `style.zIndex = "9999"` and **then** captured `originalZIndex` — so the captured value was always `9999`, and the drag-end restore wrote `9999` back permanently. Any inline z-index the user had is also clobbered.

## Fix
Capture the inline z-index before elevating the node (one-statement move).

## Testing
- New Playwright regression test (`playwright/tests/drag/zindex.spec.ts`): inline z-index must be empty after a completed drag.
- Verified red→green: the test fails with `Received: "9999"` on the unfixed code and passes with the fix.

Closes #154 (superseded; credited via co-author trailer).