### PR TITLE
fix: include actual counts in draggable items mismatch warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1173,18 +1173,15 @@ export function remapNodes<T>(parent: HTMLElement, force?: boolean) {
     }
   }
 
-  if (
-    enabledNodes.length !== parentData.getValues(parent).length &&
-    !config.disabled
-  ) {
+  const values = parentData.getValues(parent);
+
+  if (enabledNodes.length !== values.length && !config.disabled) {
     console.warn(
-      "The number of draggable items defined in the parent element does not match the number of values. This may cause unexpected behavior."
+      `The number of draggable items (${enabledNodes.length}) defined in the parent element does not match the number of values (${values.length}). This may cause unexpected behavior.`
     );
 
     return;
   }
-
-  const values = parentData.getValues(parent);
 
   const enabledNodeRecords: Array<NodeRecord<T>> = [];
 


### PR DESCRIPTION
Lands the idea from #167 by @unstoppablecarl against `release/0.6.0`.

## What
The count-mismatch warning in `remapNodes` now interpolates both numbers:

> The number of draggable items (3) defined in the parent element does not match the number of values (5). …

## Differences from #167
- The original patch had the two labels swapped (`parentNodeCount` actually held the *values* count but was reported as the node count, and vice versa) — corrected here so the message doesn't mislead.
- Kept repo formatting (semicolons), and hoisted `getValues` so it's called once per remap instead of twice.

## Testing
- `tsc --noEmit` clean; message-only change on an early-return path that previously warned identically.

Closes #167 (superseded; credited via co-author trailer).