### PR TITLE
chore: add homepage, repository, and bugs fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,14 @@
   "keywords": [],
   "author": "Sasha Milenkovic <sasha@formkit.com>",
   "license": "MIT",
+  "homepage": "https://drag-and-drop.formkit.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/formkit/drag-and-drop.git"
+  },
+  "bugs": {
+    "url": "https://github.com/formkit/drag-and-drop/issues"
+  },
   "peerDependencies": {
     "@marko/runtime-tags": ">=6.0.166"
   },


### PR DESCRIPTION
Lands #119 by @ghiscoding against `release/0.6.0` — the original PR predates the 0.6.0 package.json restructuring and no longer applies, so the three fields are re-typed by hand (with co-author credit).

One deliberate difference: `homepage` points at https://drag-and-drop.formkit.com (the docs site) rather than the GitHub URL, since we have a real homepage; `repository`/`bugs` match the original.

## Verification
Ran `pnpm run build` and confirmed `dist/package.json` (the published manifest) carries all three fields and stays non-private.

Closes #119 (superseded).