### PR TITLE
fix(insert): respect group and accepts rules when showing the insert point

### DIFF
--- a/playwright/tests/drag/insert-groups.spec.ts
+++ b/playwright/tests/drag/insert-groups.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, Page } from "@playwright/test";
+import { drag } from "../../utils";
+
+let page: Page;
+
+test.beforeEach(async ({ browser }) => {
+  page = await browser.newPage();
+  await page.goto("http://localhost:3001/insert/groups");
+  await new Promise((r) => setTimeout(r, 1000));
+});
+
+test.describe("Insert plugin group validation (#149, #151)", async () => {
+  test("transfers between lists sharing a group", async () => {
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Cherry", position: "center" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#values_b")).toContainText("Apple");
+    await expect(page.locator("#values_a")).not.toContainText("Apple");
+  });
+
+  test("does not transfer between lists with different groups", async () => {
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Eggplant", position: "center" },
+      dragStart: true,
+    });
+    // The insert point must not be offered over a foreign-group list.
+    await expect(page.locator("#insert-point")).toBeHidden();
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Eggplant", position: "center" },
+      drop: true,
+    });
+    await expect(page.locator("#values_a")).toHaveText("Apple Banana");
+    await expect(page.locator("#values_c")).toHaveText("Eggplant Fig");
+  });
+
+  test("does not transfer between independent lists with no group", async () => {
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Honeydew", position: "center" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#values_a")).toHaveText("Apple Banana");
+    await expect(page.locator("#values_e")).toHaveText("Honeydew Iceberg");
+  });
+
+  test("transfers into a list whose accepts() allows the drag", async () => {
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Grape", position: "center" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#values_d")).toContainText("Apple");
+    await expect(page.locator("#values_a")).not.toContainText("Apple");
+  });
+
+  test("still sorts within a no-group list", async () => {
+    await drag(page, {
+      originEl: { id: "Honeydew", position: "center" },
+      destinationEl: { id: "Iceberg", position: "bottom" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#values_e")).toHaveText("Iceberg Honeydew");
+  });
+
+  test("shows the insert point over a same-group list", async () => {
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Cherry", position: "center" },
+      dragStart: true,
+    });
+    await expect(page.locator("#insert-point")).toBeVisible();
+  });
+});

--- a/playwright/utils.ts
+++ b/playwright/utils.ts
@@ -78,10 +78,33 @@ export async function drag(page: Page, data: DragDropData): Promise<void> {
 
     const dataTransfer = new DataTransfer();
 
-    const getEventProps = (element: Element) => {
+    const getEventProps = (element: Element, position = "center") => {
       const rect = element.getBoundingClientRect();
 
-      const [x, y] = [rect.x + rect.width / 2, rect.y + rect.height / 2];
+      let x = rect.x;
+      let y = rect.y;
+
+      switch (position) {
+        case "top":
+          x += rect.width / 2;
+          y += 5;
+          break;
+        case "bottom":
+          x += rect.width / 2;
+          y += rect.height - 5;
+          break;
+        case "left":
+          x += 5;
+          y += rect.height / 2;
+          break;
+        case "right":
+          x += rect.width - 5;
+          y += rect.height / 2;
+          break;
+        default:
+          x += rect.width / 2;
+          y += rect.height / 2;
+      }
 
       return {
         bubbles: true,
@@ -96,7 +119,10 @@ export async function drag(page: Page, data: DragDropData): Promise<void> {
 
     if (data.dragStart) {
       originElement.dispatchEvent(
-        new DragEvent("dragstart", getEventProps(originElement))
+        new DragEvent(
+          "dragstart",
+          getEventProps(originElement, data.originEl.position)
+        )
       );
     }
 
@@ -104,12 +130,18 @@ export async function drag(page: Page, data: DragDropData): Promise<void> {
 
     // Dragover the origin element
     originElement.dispatchEvent(
-      new DragEvent("dragover", getEventProps(originElement))
+      new DragEvent(
+        "dragover",
+        getEventProps(originElement, data.originEl.position)
+      )
     );
 
     await new Promise((resolve) => setTimeout(resolve, 200));
 
-    const destinationEventProps = getEventProps(destinationElement);
+    const destinationEventProps = getEventProps(
+      destinationElement,
+      data.destinationEl.position
+    );
 
     // Dragover the destination target
     destinationElement.dispatchEvent(
@@ -127,7 +159,7 @@ export async function drag(page: Page, data: DragDropData): Promise<void> {
 
     if (data.drop) {
       destinationElement.dispatchEvent(
-        new DragEvent("drop", getEventProps(destinationElement))
+        new DragEvent("drop", destinationEventProps)
       );
 
       await new Promise((resolve) => setTimeout(resolve, 200));

--- a/src/plugins/insert/index.ts
+++ b/src/plugins/insert/index.ts
@@ -11,7 +11,6 @@ import type {
   BaseDragState,
   InsertState,
   Coordinates,
-  Node,
 } from "../../types";
 
 import {
@@ -25,7 +24,6 @@ import {
   removeClass,
   addEvents,
   remapNodes,
-  nodes,
 } from "../../index";
 
 import { eq, pd, eventCoordinates } from "../../utils";
@@ -151,6 +149,39 @@ function findFirstOverflowingParent(element: HTMLElement): HTMLElement | null {
   return null; // No overflowing parent found
 }
 
+/**
+ * Whether the dragged nodes may be dropped into the given parent. Mirrors the
+ * core validateTransfer() semantics: the initial parent is always valid, and
+ * any other parent must opt in via accepts() or share the initial parent's
+ * group.
+ */
+function isValidDropTarget<T>(
+  target: ParentRecord<T>,
+  state: DragState<T>
+): boolean {
+  if (target.el === state.initialParent.el) return true;
+
+  const targetConfig = target.data.config;
+
+  if (state.draggedNode.el.contains(target.el)) return false;
+
+  if (targetConfig.dropZone === false) return false;
+
+  if (targetConfig.accepts) {
+    return targetConfig.accepts(
+      target,
+      state.initialParent,
+      state.currentParent,
+      state
+    );
+  }
+
+  return (
+    !!targetConfig.group &&
+    targetConfig.group === state.initialParent.data.config.group
+  );
+}
+
 function checkPosition(e: DragEvent | PointerEvent) {
   if (!isDragState(state)) return;
 
@@ -161,20 +192,28 @@ function checkPosition(e: DragEvent | PointerEvent) {
     return;
   }
 
-  // 2. Traverse up the DOM from the element under the cursor
-  //    to see if any ancestor is a registered parent.
+  // 2. Traverse up the DOM from the element under the cursor looking for a
+  //    registered parent that can actually receive the dragged nodes. The
+  //    walk continues past registered parents that fail validation so that
+  //    nested lists with different groups don't mask a valid ancestor (e.g.
+  //    dragging a column while hovering the cards list inside it).
   let isWithinAParent = false;
   let current: HTMLElement | null = el;
   while (current) {
-    if (nodes.has(current as Node) || parents.has(current)) {
+    const parentData = parents.get(current);
+    if (
+      parentData &&
+      isValidDropTarget({ el: current, data: parentData }, state)
+    ) {
       isWithinAParent = true;
-      break; // Found a registered parent ancestor
+      break; // Found a valid registered parent ancestor
     }
     if (current === document.body) break; // Stop if we reach the body
     current = current.parentElement;
   }
 
-  // 3. If the cursor is NOT within any registered parent...
+  // 3. If the cursor is NOT within a registered parent that can receive the
+  //    dragged nodes...
   if (!isWithinAParent) {
     // Hide the insert point if it exists
     if (insertState.insertPoint) {
@@ -441,11 +480,12 @@ function processParentDragEvent<T>(
 
   if (realTargetParent.el === state.currentParent?.el) {
     moveBetween(realTargetParent, state);
-  } else {
-    moveOutside(realTargetParent, state);
+  } else if (moveOutside(realTargetParent, state)) {
+    // Only adopt the hovered parent as the current parent when it can
+    // actually receive the dragged nodes — otherwise handleEnd would
+    // transfer values into a list whose group/accepts rules reject them.
+    state.currentParent = realTargetParent;
   }
-
-  state.currentParent = realTargetParent;
 }
 
 export function handleParentDragover<T>(
@@ -503,30 +543,12 @@ export function moveBetween<T>(data: ParentRecord<T>, state: DragState<T>) {
   }
 }
 
-function moveOutside<T>(data: ParentRecord<T>, state: DragState<T>) {
+function moveOutside<T>(data: ParentRecord<T>, state: DragState<T>): boolean {
   if (data.el === state.currentParent.el) return false;
 
+  if (!isValidDropTarget(data, state)) return false;
+
   const targetConfig = data.data.config;
-
-  if (state.draggedNode.el.contains(data.el)) return false;
-
-  if (targetConfig.dropZone === false) return;
-
-  const initialParentConfig = state.initialParent.data.config;
-
-  if (targetConfig.accepts) {
-    return targetConfig.accepts(
-      data,
-      state.initialParent,
-      state.currentParent,
-      state
-    );
-  } else if (
-    !targetConfig.group ||
-    targetConfig.group !== initialParentConfig.group
-  ) {
-    return false;
-  }
 
   const values = data.data.getValues(data.el);
 
@@ -545,25 +567,25 @@ function moveOutside<T>(data: ParentRecord<T>, state: DragState<T>) {
 
     const foundRange = findClosest(enabledNodes, state);
 
-    if (!foundRange) return;
+    if (!foundRange) return true;
 
     const key = foundRange[1] as "ascending" | "descending";
 
-    if (foundRange) {
-      const position = foundRange[0].data.range
-        ? foundRange[0].data.range[key]
-        : undefined;
+    const position = foundRange[0].data.range
+      ? foundRange[0].data.range[key]
+      : undefined;
 
-      if (position)
-        positionInsertPoint(
-          data,
-          position,
-          foundRange[1] === "ascending",
-          foundRange[0],
-          insertState as InsertState<T>
-        );
-    }
+    if (position)
+      positionInsertPoint(
+        data,
+        position,
+        foundRange[1] === "ascending",
+        foundRange[0],
+        insertState as InsertState<T>
+      );
   }
+
+  return true;
 }
 
 function findClosest<T>(enabledNodes: NodeRecord<T>[], state: DragState<T>) {

--- a/tests/pages/insert/groups.vue
+++ b/tests/pages/insert/groups.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { useDragAndDrop } from "../../../src/vue/index";
+import { insert } from "../../../src/index";
+
+function insertPoint() {
+  return () => {
+    const div = document.createElement("div");
+
+    div.id = "insert-point";
+    div.classList.add("insert-point");
+
+    return div;
+  };
+}
+
+const [parentA, valuesA] = useDragAndDrop(["Apple", "Banana"], {
+  group: "produce",
+  plugins: [insert({ insertPoint: insertPoint() })],
+});
+
+const [parentB, valuesB] = useDragAndDrop(["Cherry", "Date"], {
+  group: "produce",
+  plugins: [insert({ insertPoint: insertPoint() })],
+});
+
+const [parentC, valuesC] = useDragAndDrop(["Eggplant", "Fig"], {
+  group: "other",
+  plugins: [insert({ insertPoint: insertPoint() })],
+});
+
+const [parentD, valuesD] = useDragAndDrop(["Grape", "Kiwi"], {
+  accepts: () => true,
+  plugins: [insert({ insertPoint: insertPoint() })],
+});
+
+const [parentE, valuesE] = useDragAndDrop(["Honeydew", "Iceberg"], {
+  plugins: [insert({ insertPoint: insertPoint() })],
+});
+</script>
+
+<template>
+  <h2>Insert Plugin — group validation</h2>
+  <div class="page-container">
+    <div>
+      <h3>List A (group: produce)</h3>
+      <ul ref="parentA" class="list">
+        <li v-for="value in valuesA" :id="value" :key="value" class="item">
+          {{ value }}
+        </li>
+      </ul>
+      <span id="values_a">{{ valuesA.join(" ") }}</span>
+    </div>
+    <div>
+      <h3>List B (group: produce)</h3>
+      <ul ref="parentB" class="list">
+        <li v-for="value in valuesB" :id="value" :key="value" class="item">
+          {{ value }}
+        </li>
+      </ul>
+      <span id="values_b">{{ valuesB.join(" ") }}</span>
+    </div>
+    <div>
+      <h3>List C (group: other)</h3>
+      <ul ref="parentC" class="list">
+        <li v-for="value in valuesC" :id="value" :key="value" class="item">
+          {{ value }}
+        </li>
+      </ul>
+      <span id="values_c">{{ valuesC.join(" ") }}</span>
+    </div>
+    <div>
+      <h3>List D (accepts: always)</h3>
+      <ul ref="parentD" class="list">
+        <li v-for="value in valuesD" :id="value" :key="value" class="item">
+          {{ value }}
+        </li>
+      </ul>
+      <span id="values_d">{{ valuesD.join(" ") }}</span>
+    </div>
+    <div>
+      <h3>List E (no group)</h3>
+      <ul ref="parentE" class="list">
+        <li v-for="value in valuesE" :id="value" :key="value" class="item">
+          {{ value }}
+        </li>
+      </ul>
+      <span id="values_e">{{ valuesE.join(" ") }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.list {
+  min-height: 40px;
+}
+</style>
+
+<style>
+.insert-point {
+  position: absolute;
+  background: blue;
+  height: 4px;
+  box-sizing: border-box;
+}
+</style>


### PR DESCRIPTION
Fixes #149 and #151, building on the diagnosis and approach from #152 by @Vexcited (credited as co-author).

## Bugs
The insert plugin bypassed transfer validation in three ways:
1. `processParentDragEvent` adopted any hovered parent as `state.currentParent` even when `moveOutside`'s group/accepts checks **rejected** it — so `handleEnd` happily transferred values into lists that should never receive them (#151), and the insert point appeared over unrelated parent lists during nested drags (#149).
2. `checkPosition` treated *any* registered parent under the cursor as a valid hover region, so the indicator stayed visible over foreign lists.
3. `moveOutside` returned early when `accepts()` passed, skipping the insert point UI until a second dragover.

## Fix
- New `isValidDropTarget()` helper mirroring core `validateTransfer` semantics: initial parent always valid; otherwise `dropZone !== false`, then `accepts()` if present, else **truthy** group equality.
- `processParentDragEvent` only adopts the hovered parent when `moveOutside` validates.
- `checkPosition`'s ancestor walk continues **past** invalid parents (this differs from #152, which stopped at the first registered parent — that would hide the indicator when dragging an outer-list item while hovering a nested inner list of a different group).
- Two no-group lists are *not* mutually valid (matches core: `validateTransfer` requires a truthy shared group or `accepts`). This is exactly the repro in #151.

## Tests
New page `tests/pages/insert/groups.vue` (5 lists: same-group pair, foreign group, `accepts: () => true`, no-group) + `playwright/tests/drag/insert-groups.spec.ts`:
- same-group transfer works; insert point visible
- foreign-group: insert point hidden, drop is a no-op
- no-group pair: drop is a no-op
- `accepts` list receives the drag
- within-list sorting still works on a no-group list

On unfixed code the cross-list assertions fail (items leak into foreign/no-group lists) — verified red→green. The `drag()` Playwright helper now honors the `position` field (`top`/`bottom`/…) like `syntheticDrag` already did; default remains center so existing specs are untouched.

Full suite: **104 passed, 0 failed** (Chrome/Firefox/WebKit + mobile synth).