### PR TITLE
fix: support drag handles inside shadow DOM

### DIFF
--- a/playwright/tests/drag/draghandle-shadow.spec.ts
+++ b/playwright/tests/drag/draghandle-shadow.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, Page } from "@playwright/test";
+import { drag } from "../../utils";
+
+let page: Page;
+
+test.beforeEach(async ({ browser }) => {
+  page = await browser.newPage();
+  await page.goto("http://localhost:3001/draghandle/shadow");
+  await new Promise((r) => setTimeout(r, 1000));
+});
+
+/**
+ * Dispatches a pointerdown on an element that may live inside an open shadow
+ * root, the way a real pointerdown would occur (composed, bubbling out of the
+ * shadow tree). Native dragstart then fires on the draggable element itself,
+ * which is what the drag() helper dispatches — matching real browser order.
+ */
+async function pointerdownDeep(page: Page, id: string) {
+  await page.evaluate((id) => {
+    function findDeep(root: Document | ShadowRoot): Element | null {
+      const direct = root.querySelector(`#${CSS.escape(id)}`);
+      if (direct) return direct;
+      for (const el of Array.from(root.querySelectorAll("*"))) {
+        if (el.shadowRoot) {
+          const found = findDeep(el.shadowRoot);
+          if (found) return found;
+        }
+      }
+      return null;
+    }
+
+    const el = findDeep(document);
+
+    if (!el) throw new Error(`Element not found: ${id}`);
+
+    const rect = el.getBoundingClientRect();
+    const x = rect.x + rect.width / 2;
+    const y = rect.y + rect.height / 2;
+
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        button: 0,
+        buttons: 1,
+        clientX: x,
+        clientY: y,
+        pointerId: 1,
+        pointerType: "mouse",
+        screenX: x,
+        screenY: y,
+      })
+    );
+  }, id);
+}
+
+test.describe("Drag handles inside shadow DOM (#170)", async () => {
+  test("item drags when the pointer goes down on its shadow DOM handle", async () => {
+    await pointerdownDeep(page, "Apple_shadowHandle");
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#shadow_values")).toHaveText(
+      "Banana Apple Orange"
+    );
+  });
+
+  test("item does not drag when the pointer goes down outside the handle", async () => {
+    await pointerdownDeep(page, "Apple");
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#shadow_values")).toHaveText(
+      "Apple Banana Orange"
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1351,20 +1351,25 @@ function handleParentScroll<T>(_data: ParentEventData<T>) {
  */
 export function handleDragstart<T>(
   data: NodeDragEventData<T>,
-  _state: BaseDragState<T>
+  state: BaseDragState<T>
 ) {
   const config = data.targetData.parent.data.config;
 
-  if (
-    !config.nativeDrag ||
-    !validateDragstart(data) ||
-    !validateDragHandle({
-      x: data.e.clientX,
-      y: data.e.clientY,
-      node: data.targetData.node,
-      config,
-    })
-  ) {
+  // Native dragstart fires on the draggable node itself, so a handle inside
+  // a shadow root is never part of this event's path. Reuse the validation
+  // performed on pointerdown (whose composed path does include the handle)
+  // when it refers to the same node; fall back to validating this event
+  // directly (e.g. Safari, where pointerdown may not have fired).
+  const validated =
+    state.pointerDown && state.pointerDown.node.el === data.targetData.node.el
+      ? state.pointerDown.validated
+      : validateDragHandle({
+          e: data.e,
+          node: data.targetData.node,
+          config,
+        });
+
+  if (!config.nativeDrag || !validateDragstart(data) || !validated) {
     pd(data.e);
 
     return;
@@ -1414,8 +1419,7 @@ export function handleNodePointerdown<T>(
 
   if (
     !validateDragHandle({
-      x: data.e.clientX,
-      y: data.e.clientY,
+      e: data.e,
       node: data.targetData.node,
       config: data.targetData.parent.data.config,
     })
@@ -1682,13 +1686,11 @@ export function initDrag<T>(
 }
 
 export function validateDragHandle<T>({
-  x,
-  y,
+  e,
   node,
   config,
 }: {
-  x: number;
-  y: number;
+  e: PointerEvent | DragEvent;
   node: NodeRecord<T>;
   config: ParentConfig<T>;
 }): boolean {
@@ -1696,11 +1698,25 @@ export function validateDragHandle<T>({
 
   if (!config.dragHandle) return true;
 
+  // Events that originate inside a shadow root are retargeted to the host
+  // element, so querySelectorAll/elementFromPoint can never see the handle.
+  // composedPath() exposes the real path; only elements between the event
+  // origin and the draggable node itself can count as the node's handle.
+  const path = e.composedPath();
+
+  const nodeIndex = path.indexOf(node.el);
+
+  for (const target of nodeIndex === -1 ? [] : path.slice(0, nodeIndex)) {
+    if (target instanceof Element && target.matches(config.dragHandle))
+      return true;
+  }
+
+  // Fallback for events that fire on the draggable node itself (native
+  // dragstart targets the draggable element, not the handle): hit-test the
+  // handle from the event coordinates.
   const dragHandles = node.el.querySelectorAll(config.dragHandle);
 
-  if (!dragHandles) return false;
-
-  const elFromPoint = config.root.elementFromPoint(x, y);
+  const elFromPoint = config.root.elementFromPoint(e.clientX, e.clientY);
 
   if (!elFromPoint) return false;
 

--- a/tests/pages/dragHandle/shadow.vue
+++ b/tests/pages/dragHandle/shadow.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { useDragAndDrop } from "../../../src/vue/index";
+
+const [parent, values] = useDragAndDrop(["Apple", "Banana", "Orange"], {
+  dragHandle: ".dragHandle",
+});
+
+onMounted(() => {
+  // Render each item's drag handle inside an open shadow root so the handle
+  // is invisible to light-DOM queries (querySelectorAll/elementFromPoint).
+  document.querySelectorAll<HTMLElement>(".shadow-host").forEach((host) => {
+    const root = host.attachShadow({ mode: "open" });
+
+    const handle = document.createElement("span");
+
+    handle.id = host.dataset.handleId as string;
+    handle.className = "dragHandle";
+    handle.textContent = "⠿";
+
+    root.appendChild(handle);
+  });
+});
+</script>
+
+<template>
+  <h1>Drag Handles in Shadow DOM</h1>
+  <ul ref="parent" class="list">
+    <li v-for="value in values" :id="value" :key="value" class="item">
+      <span
+        class="shadow-host"
+        :data-handle-id="value + '_shadowHandle'"
+      ></span>
+      <span>{{ value }}</span>
+    </li>
+  </ul>
+  <div class="values">
+    Values:
+    <span id="shadow_values">{{ values.join(" ") }}</span>
+  </div>
+</template>


### PR DESCRIPTION
Fixes #170. Reimplements the approach from #171/#172 by @driskull (credited as co-author), with one structural change that both of those PRs needed.

## Why not merge #171 or #172 directly
Both PRs validate the **dragstart** event's `composedPath()` against the handle selector. That works in tests that dispatch synthetic dragstart events *on the handle element*, but real browsers fire native `dragstart` on the **draggable element itself** — the handle is never in that event's composed path. Merging either PR would have shipped a fix that passes its own tests but doesn't work for real native drags (and #171's rewrite would have regressed light-DOM handles on native drag too, since it removed the coordinate hit-test for everyone).

## What this does instead
- `validateDragHandle` now takes the event and scans `e.composedPath()` (bounded to elements inside the draggable node — same bounding idea as #171) before falling back to the existing `querySelectorAll`/`elementFromPoint` hit-test. This fixes **pointerdown** validation for shadow handles, which also fixes synthetic/touch drags since that path keys off `pointerDown.validated`.
- `handleDragstart` reuses the pointerdown validation when it refers to the same node, because the dragstart event itself can never see the handle. Falls back to direct event validation when no pointerdown fired (the Safari case already noted in the code).
- No new config option (unlike #172) — `dragHandle` just works in shadow DOM.

## Tests
New page `tests/pages/dragHandle/shadow.vue` (handles rendered in open shadow roots) + `playwright/tests/drag/draghandle-shadow.spec.ts` using **real event ordering**: composed `pointerdown` on the shadow handle, then `dragstart` on the draggable element — not dragstart-on-handle, which masks the bug.
- Positive: drag via shadow handle sorts the list — fails red on unfixed code, green with fix.
- Negative: pointerdown on the item body does not drag.
- Existing light-DOM `draghandle` spec untouched and passing.

Full suite: **110 passed, 0 failed** across Chrome/Firefox/WebKit + mobile synth.

Closes #171, closes #172 (superseded).