### PR TITLE
fix: do not schedule the long press timer when longPress is disabled

### DIFF
--- a/playwright/tests/synthetic-drag/longpress.spec.ts
+++ b/playwright/tests/synthetic-drag/longpress.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, Page } from "@playwright/test";
+import { syntheticDrag } from "../../utils";
+
+let page: Page;
+let pageErrors: string[];
+
+test.beforeEach(async ({ browser }) => {
+  page = await browser.newPage();
+  pageErrors = [];
+  page.on("pageerror", (err) => pageErrors.push(String(err)));
+});
+
+async function holdPointer(page: Page, id: string, ms: number) {
+  await page.evaluate((id) => {
+    const el = document.getElementById(id);
+    if (!el) throw new Error(`Element not found: ${id}`);
+    const rect = el.getBoundingClientRect();
+    const x = rect.x + rect.width / 2;
+    const y = rect.y + rect.height / 2;
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        button: 0,
+        buttons: 1,
+        clientX: x,
+        clientY: y,
+        pointerId: 1,
+        pointerType: "touch",
+        screenX: x,
+        screenY: y,
+      })
+    );
+  }, id);
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+async function releasePointer(page: Page, id: string) {
+  await page.evaluate((id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerup", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        button: 0,
+        buttons: 0,
+        clientX: rect.x + rect.width / 2,
+        clientY: rect.y + rect.height / 2,
+        pointerId: 1,
+        pointerType: "touch",
+      })
+    );
+  }, id);
+}
+
+test.describe("Long press config (#173)", async () => {
+  test("a long hold with longPress disabled is a no-op", async () => {
+    await page.goto("http://localhost:3001/sort/longpress-disabled");
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // Hold past the default longPressDuration (1000ms) without moving.
+    await holdPointer(page, "Apple", 1300);
+
+    // The long press timer must not have fired: no long press class, no
+    // uncaught errors.
+    await expect(page.locator("#Apple")).not.toHaveClass(/long-press/);
+    expect(pageErrors).toEqual([]);
+
+    await releasePointer(page, "Apple");
+
+    // Dragging afterwards still works normally.
+    await syntheticDrag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#sort_values")).toHaveText(
+      "Banana Apple Orange"
+    );
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("longPress: true still applies the class and drags after the hold", async () => {
+    await page.goto("http://localhost:3001/sort/longpress");
+    await new Promise((r) => setTimeout(r, 1000));
+
+    await holdPointer(page, "Apple", 1300);
+
+    await expect(page.locator("#Apple")).toHaveClass(/long-press/);
+
+    await releasePointer(page, "Apple");
+
+    // A drag that includes the hold works end to end.
+    await holdPointer(page, "Apple", 1300);
+    await syntheticDrag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      drop: true,
+    });
+    await expect(page.locator("#sort_values")).toHaveText(
+      "Banana Apple Orange"
+    );
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2166,6 +2166,11 @@ export function handleLongPress<T>(
 ) {
   const config = data.targetData.parent.data.config;
 
+  // Long press is opt-in. Without it, a press-and-hold is simply a pointer
+  // that has not moved yet — scheduling the timeout anyway mutated drag state
+  // and preventDefault-ed a stale event one second into every touch hold.
+  if (!config.longPress) return;
+
   state.longPressTimeout = setTimeout(() => {
     if (!state) return;
 

--- a/tests/pages/sort/longpress-disabled.vue
+++ b/tests/pages/sort/longpress-disabled.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { useDragAndDrop } from "../../../src/vue/index";
+
+// longPress is intentionally NOT enabled: the longPressClass must never be
+// applied, because the long press timer should not even be scheduled (#173).
+const [parent, values] = useDragAndDrop(["Apple", "Banana", "Orange"], {
+  longPressClass: "long-press",
+});
+</script>
+
+<template>
+  <div class="page-container">
+    <h1>Long press disabled</h1>
+    <ul ref="parent" class="list">
+      <li v-for="value in values" :id="value" :key="value" class="item">
+        {{ value }}
+      </li>
+    </ul>
+    <div class="values">
+      Values:
+      <span id="sort_values">
+        {{ values.map((x) => x).join(" ") }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/tests/pages/sort/longpress.vue
+++ b/tests/pages/sort/longpress.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { useDragAndDrop } from "../../../src/vue/index";
+
+const [parent, values] = useDragAndDrop(["Apple", "Banana", "Orange"], {
+  longPress: true,
+  longPressClass: "long-press",
+});
+</script>
+
+<template>
+  <div class="page-container">
+    <h1>Long press enabled</h1>
+    <ul ref="parent" class="list">
+      <li v-for="value in values" :id="value" :key="value" class="item">
+        {{ value }}
+      </li>
+    </ul>
+    <div class="values">
+      Values:
+      <span id="sort_values">
+        {{ values.map((x) => x).join(" ") }}
+      </span>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Fixes #173 (TypeError on mobile 1s hold with `longPress: false`).

## Bug
`handleLongPress` scheduled its timeout regardless of `config.longPress`. After `longPressDuration` (default 1000ms) of holding, the timer fired anyway: set `state.longPress = true`, applied `longPressClass`, and called `preventDefault()` on the stale pointerdown — mid-hold state corruption for a feature that was never enabled, crashing on Android Chrome per the report.

## Fix
One guard: `if (!config.longPress) return;` before arming the timer. The flag's only consumer (`handleRootPointermove`) is already gated on `config.longPress`, so the timer serves no purpose when the feature is off.

## Tests
New `playwright/tests/synthetic-drag/longpress.spec.ts` + two test pages, run on the iPhone 13 mobile project:
- **disabled**: 1.3s hold → `longPressClass` must not appear, no page errors, dragging still works after release. **Red on unfixed code** (class appears, proving the timer fired) → green with fix.
- **enabled**: 1.3s hold applies the class; drag-with-hold sorts end to end (guards against over-suppression).