### PR TITLE
fix(dropOrSwap): validate group and accepts rules during hover and drop

### DIFF
--- a/playwright/tests/drag/drop-or-swap-groups.spec.ts
+++ b/playwright/tests/drag/drop-or-swap-groups.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, Page } from "@playwright/test";
+import { drag } from "../../utils";
+
+let page: Page;
+
+test.beforeEach(async ({ browser }) => {
+  page = await browser.newPage();
+  await page.goto("http://localhost:3001/drop-or-swap/groups");
+  await new Promise((r) => setTimeout(r, 1000));
+});
+
+test.describe("dropOrSwap group validation (#157, #148)", async () => {
+  test("transfers between lists sharing a group", async () => {
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Cherry", position: "center" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#values_b")).toContainText("Apple");
+    await expect(page.locator("#values_a")).not.toContainText("Apple");
+  });
+
+  test("does not transfer between lists with different groups (#157)", async () => {
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Eggplant", position: "center" },
+      dragStart: true,
+    });
+    // No drop-target styling may be offered over a foreign-group list.
+    await expect(page.locator("#list_c")).not.toHaveClass(/dropZoneParent/);
+    await expect(page.locator("#Eggplant")).not.toHaveClass(/dropZone/);
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Eggplant", position: "center" },
+      drop: true,
+    });
+    await expect(page.locator("#values_a")).toHaveText("Apple Banana");
+    await expect(page.locator("#values_c")).toHaveText("Eggplant Fig");
+  });
+
+  test("does not transfer between independent no-group lists", async () => {
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Honeydew", position: "center" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#values_a")).toHaveText("Apple Banana");
+    await expect(page.locator("#values_e")).toHaveText("Honeydew Iceberg");
+  });
+
+  test("accepts() fires during hover, not only on release (#148)", async () => {
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Grape", position: "center" },
+      dragStart: true,
+    });
+    // accepts() must have been consulted while hovering.
+    const calls = Number(await page.locator("#accepts_calls").textContent());
+    expect(calls).toBeGreaterThan(0);
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Grape", position: "center" },
+      drop: true,
+    });
+    await expect(page.locator("#values_d")).toContainText("Apple");
+    await expect(page.locator("#values_a")).not.toContainText("Apple");
+  });
+
+  test("still sorts within a no-group list", async () => {
+    await drag(page, {
+      originEl: { id: "Honeydew", position: "center" },
+      destinationEl: { id: "Iceberg", position: "center" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#values_e")).toHaveText("Iceberg Honeydew");
+  });
+});

--- a/src/plugins/drop-or-swap/index.ts
+++ b/src/plugins/drop-or-swap/index.ts
@@ -22,6 +22,7 @@ import {
   state,
   addEvents,
   isDragState,
+  validateTransfer,
 } from "../../index";
 
 export const dropSwapState: DropSwapState<unknown> = {
@@ -110,12 +111,67 @@ function rootPointerover(_e: CustomEvent) {
   state.currentParent = state.initialParent;
 }
 
+/**
+ * Whether the dragged nodes may be dropped into the given parent. Hovering
+ * the parent the drag is currently over (or started from) is always allowed;
+ * everything else must pass the core transfer rules (group/accepts/dropZone).
+ */
+function canTransferTo<T>(
+  targetParent: ParentRecord<T>,
+  state: DragState<T> | SynthDragState<T>
+): boolean {
+  if (targetParent.el === state.currentParent.el) return true;
+
+  if (targetParent.el === state.initialParent.el) return true;
+
+  return validateTransfer({
+    currentParent: state.currentParent,
+    targetParent,
+    initialParent: state.initialParent,
+    draggedNodes: state.draggedNodes,
+    state,
+  });
+}
+
+/**
+ * Clears any hover targeting so a drop over an invalid parent is a no-op:
+ * handleEnd returns early when no nodes are targeted and the current parent
+ * is back to the initial one.
+ */
+function resetDraggedOverNodes<T>(state: DragState<T> | SynthDragState<T>) {
+  const config = state.currentParent.data.config;
+
+  const isSynth = isSynthDragState(state);
+
+  removeClass(
+    dropSwapState.draggedOverNodes.map((node) => node.el),
+    isSynth ? config.synthDropZoneClass : config.dropZoneClass
+  );
+
+  removeClass(
+    [state.currentParent.el],
+    isSynth ? config.synthDropZoneParentClass : config.dropZoneParentClass
+  );
+
+  dropSwapState.draggedOverNodes = [];
+
+  state.currentTargetValue = undefined;
+
+  state.currentParent = state.initialParent;
+}
+
 function updateDraggedOverNodes<T>(
   data: PointeroverNodeEvent<T> | NodeDragEventData<T>,
   state: DragState<T> | SynthDragState<T>
 ) {
   const targetData =
     "detail" in data ? data.detail.targetData : data.targetData;
+
+  if (!canTransferTo(targetData.parent, state)) {
+    resetDraggedOverNodes(state);
+
+    return;
+  }
 
   const config = targetData.parent.data.config;
 
@@ -176,6 +232,12 @@ export function handleParentDragover<T>(
 
   data.e.stopPropagation();
 
+  if (!canTransferTo(data.targetData.parent, state)) {
+    resetDraggedOverNodes(state);
+
+    return;
+  }
+
   const currentConfig = state.currentParent.data.config;
 
   removeClass(
@@ -200,6 +262,12 @@ export function handleParentDragover<T>(
 }
 
 export function handeParentPointerover<T>(data: PointeroverParentEvent<T>) {
+  if (!canTransferTo(data.detail.targetData.parent, data.detail.state)) {
+    resetDraggedOverNodes(data.detail.state);
+
+    return;
+  }
+
   const currentConfig = data.detail.state.currentParent.data.config;
 
   removeClass(

--- a/tests/pages/drop-or-swap/groups.vue
+++ b/tests/pages/drop-or-swap/groups.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useDragAndDrop } from "../../../src/vue/index";
+import { dropOrSwap } from "../../../src/index";
+
+const acceptsCalls = ref(0);
+
+const sharedConfig = {
+  dropZoneClass: "dropZone",
+  dropZoneParentClass: "dropZoneParent",
+  synthDropZoneClass: "synthDropZone",
+  synthDropZoneParentClass: "synthDropZoneParent",
+};
+
+const [parentA, valuesA] = useDragAndDrop(["Apple", "Banana"], {
+  ...sharedConfig,
+  group: "g1",
+  plugins: [dropOrSwap({})],
+});
+
+const [parentB, valuesB] = useDragAndDrop(["Cherry", "Date"], {
+  ...sharedConfig,
+  group: "g1",
+  plugins: [dropOrSwap({})],
+});
+
+const [parentC, valuesC] = useDragAndDrop(["Eggplant", "Fig"], {
+  ...sharedConfig,
+  group: "g2",
+  plugins: [dropOrSwap({})],
+});
+
+const [parentD, valuesD] = useDragAndDrop(["Grape", "Kiwi"], {
+  ...sharedConfig,
+  accepts: () => {
+    acceptsCalls.value++;
+    return true;
+  },
+  plugins: [dropOrSwap({})],
+});
+
+const [parentE, valuesE] = useDragAndDrop(["Honeydew", "Iceberg"], {
+  ...sharedConfig,
+  plugins: [dropOrSwap({})],
+});
+</script>
+
+<template>
+  <h2>dropOrSwap — group validation</h2>
+  <div class="page-container">
+    <div>
+      <h3>List A (group: g1)</h3>
+      <ul id="list_a" ref="parentA" class="list">
+        <li v-for="value in valuesA" :id="value" :key="value" class="item">
+          {{ value }}
+        </li>
+      </ul>
+      <span id="values_a">{{ valuesA.join(" ") }}</span>
+    </div>
+    <div>
+      <h3>List B (group: g1)</h3>
+      <ul id="list_b" ref="parentB" class="list">
+        <li v-for="value in valuesB" :id="value" :key="value" class="item">
+          {{ value }}
+        </li>
+      </ul>
+      <span id="values_b">{{ valuesB.join(" ") }}</span>
+    </div>
+    <div>
+      <h3>List C (group: g2)</h3>
+      <ul id="list_c" ref="parentC" class="list">
+        <li v-for="value in valuesC" :id="value" :key="value" class="item">
+          {{ value }}
+        </li>
+      </ul>
+      <span id="values_c">{{ valuesC.join(" ") }}</span>
+    </div>
+    <div>
+      <h3>List D (accepts: counts and allows)</h3>
+      <ul id="list_d" ref="parentD" class="list">
+        <li v-for="value in valuesD" :id="value" :key="value" class="item">
+          {{ value }}
+        </li>
+      </ul>
+      <span id="values_d">{{ valuesD.join(" ") }}</span>
+      <span id="accepts_calls">{{ acceptsCalls }}</span>
+    </div>
+    <div>
+      <h3>List E (no group)</h3>
+      <ul id="list_e" ref="parentE" class="list">
+        <li v-for="value in valuesE" :id="value" :key="value" class="item">
+          {{ value }}
+        </li>
+      </ul>
+      <span id="values_e">{{ valuesE.join(" ") }}</span>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Fixes #157 (dropOrSwap lets differently-grouped lists exchange items) and #148 (`accepts` never fires during hover with dropOrSwap).

## Bug
dropOrSwap overrides the core dragover/pointerover handlers but never calls `validateTransfer`. Consequences:
- `state.currentParent` was adopted unconditionally, so `handleEnd` transferred/swapped values into **any** registered list — different group, no group, didn't matter (#157's repro: `todoList` vs `todoListA` still transferred).
- `accepts()` was never consulted while hovering, so droppability couldn't be styled live (#148 — the insert plugin does this correctly, which is why switching plugins "fixed" it for the reporter).

## Fix
- `canTransferTo()`: current parent and initial parent always allowed; everything else goes through core `validateTransfer` (group/accepts/dropZone — same semantics as un-plugged transfers).
- All four hover entry points (node/parent × native/synth) gate on it.
- Hovering an invalid parent calls `resetDraggedOverNodes()` — clears dropzone classes, targeted nodes, and resets `currentParent` to initial — so the drop hits `handleEnd`'s existing early-return and is a true no-op (otherwise a drop over a foreign list would have swapped against stale targets in the source list).

## Tests
New page `tests/pages/drop-or-swap/groups.vue` + `playwright/tests/drag/drop-or-swap-groups.spec.ts`:
- same-group transfer works
- foreign-group: no dropzone styling during hover, drop is a no-op (**#157 repro**)
- no-group pair: drop is a no-op
- `accepts()` call count is observable in the DOM and **must increase during hover** (**#148 repro**), and the accepting list receives the item on drop
- within-list sorting unaffected

Red→green: 3 of 5 fail on the unfixed plugin. Full suite: **127 passed, 0 failed** (all browsers + mobile).