### PR TITLE
fix(types): parameterize event handler types with the config generic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -542,7 +542,7 @@ export function performSort<T>({
       parent: {
         el: parent.el,
         data: parent.data,
-      } as ParentRecord<unknown>,
+      } as ParentRecord<T>,
       previousValues: [...targetParentValues],
       previousNodes: [...enabledNodes],
       nodes: [...parent.data.enabledNodes],
@@ -551,7 +551,7 @@ export function performSort<T>({
       previousPosition: originalIndex,
       position: targetNodes[0].data.index,
       targetNodes,
-      state,
+      state: state as BaseDragState<T>,
     });
   }
 }

--- a/src/plugins/drop-or-swap/index.ts
+++ b/src/plugins/drop-or-swap/index.ts
@@ -416,7 +416,7 @@ function handleEnd<T>(state: DragState<T> | SynthDragState<T>) {
         parent: {
           el: state.initialParent.el,
           data: state.initialParent.data,
-        } as ParentRecord<unknown>,
+        } as ParentRecord<T>,
         previousValues: [...initialParentValues],
         previousNodes: [...state.initialParent.data.enabledNodes],
         nodes: [...state.initialParent.data.enabledNodes],
@@ -425,7 +425,7 @@ function handleEnd<T>(state: DragState<T> | SynthDragState<T>) {
         previousPosition: draggedIndex,
         position: targetIndex,
         targetNodes: dropSwapState.draggedOverNodes as NodeRecord<T>[],
-        state: state as BaseDragState<unknown>,
+        state: state as BaseDragState<T>,
       });
     }
   } else {

--- a/src/plugins/insert/index.ts
+++ b/src/plugins/insert/index.ts
@@ -770,16 +770,16 @@ export function handleEnd<T>(
           parent: {
             el: state.initialParent.el,
             data: state.initialParent.data,
-          } as ParentRecord<unknown>,
+          } as ParentRecord<T>,
           previousValues: [...draggedParentValues],
           previousNodes: [...enabledNodes],
           nodes: [...state.initialParent.data.enabledNodes],
           values: [...newParentValues],
           draggedNodes: state.draggedNodes,
-          targetNodes: insertState.draggedOverNodes,
+          targetNodes: insertState.draggedOverNodes as Array<NodeRecord<T>>,
           previousPosition: originalIndex,
           position: index,
-          state: state as DragState<unknown>,
+          state: state as DragState<T>,
         };
 
         state.initialParent.data.config.onSort(sortEventData);

--- a/src/types.test-d.ts
+++ b/src/types.test-d.ts
@@ -1,0 +1,38 @@
+/**
+ * Compile-time regression tests, checked by `tsc --noEmit`. Not part of any
+ * runtime bundle (nothing imports this module).
+ *
+ * #162: ParentConfig's event handlers must carry the config's generic so
+ * handler parameters are typed as the consumer's item type, not a fresh
+ * unrelated `T`.
+ */
+import type { ParentConfig } from "./types";
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+export const eventHandlerTypeChecks: Partial<ParentConfig<Item>> = {
+  onSort: (data) => {
+    const values: Array<Item> = data.values;
+    const previous: Array<Item> = data.previousValues;
+    const dragged: Item = data.draggedNodes[0].data.value;
+    void [values, previous, dragged];
+  },
+  onTransfer: (data) => {
+    const dragged: Item = data.draggedNodes[0].data.value;
+    const index: number = data.targetIndex;
+    void [dragged, index];
+  },
+  onDragstart: (data) => {
+    const values: Array<Item> = data.values;
+    const dragged: Item = data.draggedNode.data.value;
+    void [values, dragged];
+  },
+  onDragend: (data) => {
+    const values: Array<Item> = data.values;
+    const dragged: Item = data.draggedNode.data.value;
+    void [values, dragged];
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -349,19 +349,19 @@ export interface ParentConfig<T> {
   /**
    * Callback function for when a sort operation is performed.
    */
-  onSort?: SortEvent;
+  onSort?: SortEvent<T>;
   /**
    * Callback function for when a transfer operation is performed.
    */
-  onTransfer?: TransferEvent;
+  onTransfer?: TransferEvent<T>;
   /**
    * Fired when a drag is started, whether native drag or synthetic
    */
-  onDragstart?: DragstartEvent;
+  onDragstart?: DragstartEvent<T>;
   /**
    * Fired when a drag is ended, whether native drag or synthetic
    */
-  onDragend?: DragendEvent;
+  onDragend?: DragendEvent<T>;
 }
 
 /**
@@ -891,13 +891,13 @@ export interface DragStateProps<T> {
   frameIdY?: number;
 }
 
-export type SortEvent = <T>(data: SortEventData<T>) => void;
+export type SortEvent<T> = (data: SortEventData<T>) => void;
 
-export type TransferEvent = <T>(data: TransferEventData<T>) => void;
+export type TransferEvent<T> = (data: TransferEventData<T>) => void;
 
-export type DragstartEvent = <T>(data: DragstartEventData<T>) => void;
+export type DragstartEvent<T> = (data: DragstartEventData<T>) => void;
 
-export type DragendEvent = <T>(data: DragendEventData<T>) => void;
+export type DragendEvent<T> = (data: DragendEventData<T>) => void;
 
 export interface SortEventData<T> {
   parent: ParentRecord<T>;


### PR DESCRIPTION
Fixes #162.

## Bug
`onSort`/`onTransfer`/`onDragstart`/`onDragend` were typed as `SortEvent = <T>(data: SortEventData<T>) => void` — each handler introduced its **own** generic instead of reusing `ParentConfig<T>`'s. With `useDragAndDrop<HTMLDivElement, ProductSpecification>`, handler params were an unrelated `T`, so touching your item fields was a type error (the reporter's screenshots).

## Fix
- `SortEvent<T>`, `TransferEvent<T>`, `DragstartEvent<T>`, `DragendEvent<T>`, referenced as `onSort?: SortEvent<T>` etc.
- Internal payload builders that exploited the old universally-quantified form (casting `parent`/`state` to `unknown`) now cast to `T` — the strictness this change is meant to provide caught them immediately.

## Tests
`src/types.test-d.ts` — compile-time regression assertions (no runtime footprint; nothing imports it; `tsc --noEmit` is the harness). Red on old types (8 errors), green now. Framework + sort e2e sanity: 13 passed.

Note: consumers who annotated handlers with the old type names (`const f: SortEvent = …`) will need `SortEvent<MyItem>` — appropriate for the 0.6.0 release notes.