### PR TITLE
fix: stop swallowing pointerdown events from framework listeners

### DIFF
--- a/playwright/tests-frameworks/pointer-events.spec.ts
+++ b/playwright/tests-frameworks/pointer-events.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect, Page } from "@playwright/test";
+
+let page: Page;
+
+test.beforeAll(async ({ browser }) => {
+  page = await browser.newPage();
+  await page.goto("http://127.0.0.1:5173/");
+});
+
+test.describe("Consumer pointer event handlers (#166)", async () => {
+  test("React onPointerDown inside a draggable item still fires", async () => {
+    // Real input: click presses the pointer down on the button inside the
+    // draggable item. React's delegated listener at the root must receive
+    // the event — the library may not stop pointerdown propagation.
+    await page.locator("#react_drag_and_drop_10_of_clubs_button").click();
+    await expect(page.locator("#react_drag_and_drop_pointerdowns")).toHaveText(
+      "1"
+    );
+    await page.locator("#react_drag_and_drop_jack_of_hearts_button").click();
+    await expect(page.locator("#react_drag_and_drop_pointerdowns")).toHaveText(
+      "2"
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,9 +235,15 @@ export function setDragState<T>(
 }
 
 /**
- *
+ * Pointerdown events already handled by a draggable node. The node handlers
+ * no longer stop propagation (so framework-delegated listeners still fire);
+ * instead, ancestor nodes and the root handler skip claimed events.
  */
-function handleRootPointerdown() {
+const claimedPointerdowns = new WeakSet<Event>();
+
+function handleRootPointerdown(e: PointerEvent) {
+  if (claimedPointerdowns.has(e)) return;
+
   if (state.activeState) setActive(state.activeState.parent, undefined, state);
 
   if (state.selectedState)
@@ -1409,7 +1415,14 @@ export function handleNodePointerdown<T>(
   data: NodePointerEventData<T>,
   state: BaseDragState<T>
 ) {
-  sp(data.e);
+  // Claim the event for the innermost draggable node instead of stopping
+  // propagation: frameworks like React attach delegated listeners at the
+  // root, which stopPropagation silenced entirely (consumer onPointerDown
+  // handlers inside items never fired). Ancestor nodes and the root
+  // pointerdown handler skip events already claimed here.
+  if (claimedPointerdowns.has(data.e)) return;
+
+  claimedPointerdowns.add(data.e);
 
   state.pointerDown = {
     parent: data.targetData.parent,

--- a/tests-frameworks/react/components/Test1.tsx
+++ b/tests-frameworks/react/components/Test1.tsx
@@ -18,11 +18,19 @@ function Test1(props: { id: string; testDescription: string }) {
 
   const [values, setValues] = useState(playingCardAssets);
 
+  const [pointerDowns, setPointerDowns] = useState(0);
+
   const parent = React.useRef(null);
 
   const playingCards = values.map((card: { id: string; src: string }) => (
     <li className="item" key={card.id} id={props.id + "_" + card.id}>
       <img src={card.src} />
+      <button
+        id={props.id + "_" + card.id + "_button"}
+        onPointerDown={() => setPointerDowns((count) => count + 1)}
+      >
+        Inner button
+      </button>
     </li>
   ));
 
@@ -63,6 +71,7 @@ function Test1(props: { id: string; testDescription: string }) {
       <span id={props.id + "_values"}>
         {values.map((x: { id: string; src: string }) => x.id).join(" ")}
       </span>
+      <span id={props.id + "_pointerdowns"}>{pointerDowns}</span>
     </>
   );
 }


### PR DESCRIPTION
Fixes #166.

## Bug
`handleNodePointerdown` opened with `stopPropagation()`. React attaches delegated listeners at the root, so any consumer `onPointerDown` inside a draggable item simply never fired — vanilla listeners attached directly to inner elements worked, which is why this read as a React bug.

## Why stopPropagation was there (and what replaces it)
It served two real purposes: (1) nested lists — without it, an inner item's pointerdown bubbled into the outer item's handler and overwrote `state.pointerDown`; (2) the document-level `handleRootPointerdown` clears active/selected state and must not run for presses on a node.

Both are preserved with an **event claim**: the innermost node handler records the event in a module `WeakSet`; ancestor node handlers and the root handler skip claimed events. Propagation itself is untouched, so framework roots receive the event.

## Tests
- New framework e2e (`playwright/tests-frameworks/pointer-events.spec.ts`): real clicks on buttons inside React draggable items must increment an `onPointerDown` counter — **red** with the old `stopPropagation`, green now.
- Multi-drag/selection suites (which depend on root-deselection semantics) pass unchanged.
- Full suite: **130 passed, 0 failed** (all browsers + mobile).