### PR TITLE
fix: keep the draggable attribute in sync with handles and callbacks

### DIFF
--- a/playwright/tests/drag/draggable-attribute.spec.ts
+++ b/playwright/tests/drag/draggable-attribute.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect, Page } from "@playwright/test";
+
+let page: Page;
+
+test.beforeEach(async ({ browser }) => {
+  page = await browser.newPage();
+});
+
+test.describe("draggable attribute sync", async () => {
+  test("with a drag handle, items are only draggable while pressing the handle (#139)", async () => {
+    await page.goto("http://localhost:3001/draghandle");
+    await new Promise((r) => setTimeout(r, 1000));
+
+    await expect(page.locator("#Apple")).toHaveAttribute(
+      "draggable",
+      "false"
+    );
+
+    // Real pointer press on the handle arms native dragging.
+    const handle = page.locator("#Apple_dragHandle");
+    const box = await handle.boundingBox();
+    if (!box) throw new Error("handle not visible");
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await expect(page.locator("#Apple")).toHaveAttribute("draggable", "true");
+
+    // Releasing disarms it again.
+    await page.mouse.up();
+    await expect(page.locator("#Apple")).toHaveAttribute("draggable", "false");
+  });
+
+  test("text inside items with drag handles is selectable (#139)", async () => {
+    await page.goto("http://localhost:3001/draghandle");
+    await new Promise((r) => setTimeout(r, 1000));
+
+    const text = page.locator("#Apple .item-text");
+    const box = await text.boundingBox();
+    if (!box) throw new Error("item text not visible");
+
+    await page.mouse.move(box.x + 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width - 2, box.y + box.height / 2, {
+      steps: 5,
+    });
+    await page.mouse.up();
+
+    const selection = await page.evaluate(
+      () => window.getSelection()?.toString() ?? ""
+    );
+    expect(selection.length).toBeGreaterThan(0);
+  });
+
+  test("elements excluded by the draggable callback lose the attribute (#96)", async () => {
+    await page.goto("http://localhost:3001/sort/draggable-toggle");
+    await new Promise((r) => setTimeout(r, 1000));
+
+    await expect(page.locator("#Apple")).toHaveAttribute("draggable", "true");
+
+    await page.locator("#disable_dragging").click();
+
+    await expect(page.locator("#Apple")).toHaveAttribute("draggable", "false");
+    await expect(page.locator("#Banana")).toHaveAttribute(
+      "draggable",
+      "false"
+    );
+
+    await page.locator("#enable_dragging").click();
+
+    await expect(page.locator("#Apple")).toHaveAttribute("draggable", "true");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,9 @@ function handleRootPointerdown(e: PointerEvent) {
 }
 
 function handleRootPointerup() {
-  if (state.pointerDown) state.pointerDown.node.el.draggable = true;
+  if (state.pointerDown)
+    state.pointerDown.node.el.draggable =
+      !state.pointerDown.parent.data.config.dragHandle;
 
   state.pointerDown = undefined;
 
@@ -1028,7 +1030,10 @@ export function setupNode<T>(data: SetupNodeData<T>) {
     },
   });
 
-  data.node.el.draggable = true;
+  // With a drag handle configured, the node only becomes draggable once a
+  // pointerdown on the handle validates — otherwise draggable="true" would
+  // disable text selection everywhere inside the item (#139).
+  data.node.el.draggable = !config.dragHandle;
 
   config.reapplyDragClasses(data.node.el, data.parent.data);
 
@@ -1176,6 +1181,10 @@ export function remapNodes<T>(parent: HTMLElement, force?: boolean) {
 
     if (!config.draggable || (config.draggable && config.draggable(node))) {
       enabledNodes.push(node);
+    } else {
+      // Keep the DOM attribute in sync so elements excluded by the
+      // draggable callback cannot start native drags (#96).
+      node.draggable = false;
     }
   }
 
@@ -1440,6 +1449,11 @@ export function handleNodePointerdown<T>(
     return;
 
   state.pointerDown.validated = true;
+
+  // The pointer is on the drag handle: enable native dragging for the
+  // imminent dragstart (#139).
+  if (data.targetData.parent.data.config.dragHandle)
+    data.targetData.node.el.draggable = true;
 
   handleLongPress(data, state, data.targetData.node);
 
@@ -1809,7 +1823,9 @@ export function handleNodeFocus<T>(data: NodeEventData<T>) {
 export function handleNodeBlur<T>(data: NodeEventData<T>) {
   if (data.e.target === data.e.currentTarget) return;
 
-  if (state.pointerDown) state.pointerDown.node.el.draggable = true;
+  if (state.pointerDown)
+    state.pointerDown.node.el.draggable =
+      !state.pointerDown.parent.data.config.dragHandle;
 }
 
 /**
@@ -1886,7 +1902,9 @@ export function handlePointercancel<T>(
  * @returns void
  */
 export function handleEnd<T>(state: DragState<T> | SynthDragState<T>) {
-  if (state.draggedNode) state.draggedNode.el.draggable = true;
+  if (state.draggedNode)
+    state.draggedNode.el.draggable =
+      !state.currentParent.data.config.dragHandle;
 
   // --- Capture necessary data BEFORE resetState might affect it ---
   const nodesToClean = state.draggedNodes.map((x) => x.el);
@@ -1998,6 +2016,13 @@ export function handleNodePointerup<T>(
     data.targetData.parent.data.enabledNodes.map((x) => x.el),
     config.longPressClass
   );
+
+  // This handler stops propagation, so handleRootPointerup never sees
+  // releases over a node — disarm handle-gated dragging here (#139).
+  // pointerDown itself stays set: the focus/blur handlers rely on it to
+  // manage draggable while editing inner inputs (#142).
+  if (state.pointerDown && state.pointerDown.parent.data.config.dragHandle)
+    state.pointerDown.node.el.draggable = false;
 
   if (!isDragState(state)) return;
 

--- a/tests/pages/sort/draggable-toggle.vue
+++ b/tests/pages/sort/draggable-toggle.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { useDragAndDrop } from "../../../src/vue/index";
+
+const [parent, values, updateConfig] = useDragAndDrop([
+  "Apple",
+  "Banana",
+  "Orange",
+]);
+
+// Reorder-mode toggle from #96: excluding items via the draggable callback
+// must also clear the native draggable attribute.
+function disableDragging() {
+  updateConfig({ draggable: () => false });
+}
+
+function enableDragging() {
+  updateConfig({ draggable: () => true });
+}
+</script>
+
+<template>
+  <div class="page-container">
+    <h1>Draggable callback toggle</h1>
+    <ul ref="parent" class="list">
+      <li v-for="value in values" :id="value" :key="value" class="item">
+        {{ value }}
+      </li>
+    </ul>
+    <button id="disable_dragging" @click="disableDragging">
+      Disable dragging
+    </button>
+    <button id="enable_dragging" @click="enableDragging">
+      Enable dragging
+    </button>
+    <span id="sort_values">{{ values.join(" ") }}</span>
+  </div>
+</template>


### PR DESCRIPTION
Fixes #139 and #96.

## Bugs
1. **#139**: `setupNode` set `draggable="true"` unconditionally. With `dragHandle` configured the handle was only consulted later during validation — by which time the browser had already disabled text selection inside the entire item (`draggable=true` does that) and allowed native pickup from anywhere.
2. **#96**: elements excluded via the `draggable` callback kept `draggable="true"` on the MutationObserver remap path, so users could still native-drag items the library would ignore.

## Fix
- `dragHandle` parents: items start `draggable=false`; a validated pointerdown on the handle arms the attribute; release (node pointerup / root pointerup), blur, and drag end disarm it per config.
- `remapNodes` clears the attribute on callback-excluded elements.

## Subtlety (caught by the existing Firefox issue-142 spec)
A first version also cleared `state.pointerDown` on node pointerup — but the focus/blur handlers use it to suppress dragging while editing inputs inside items (#142's fix). The shipped version disarms only for `dragHandle` configs and leaves `pointerDown` semantics untouched.

## Tests
`playwright/tests/drag/draggable-attribute.spec.ts` (+ a toggle test page):
- attribute arming across a **real** mouse press/release on the handle — red on unfixed code
- **real** mouse text selection inside an item with drag handles — red on unfixed code (selection is genuinely blocked by `draggable=true`)
- draggable-callback toggle drops/restores the attribute

Full suite: **139 passed, 0 failed** (Chrome/Firefox/WebKit + mobile).