### PR TITLE
fix: tear down cleanly when components unmount mid-interaction

### DIFF
--- a/playwright/tests/drag/teardown.spec.ts
+++ b/playwright/tests/drag/teardown.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, Page } from "@playwright/test";
+import { syntheticDrag } from "../../utils";
+
+let page: Page;
+let pageErrors: string[];
+
+test.beforeEach(async ({ browser }) => {
+  page = await browser.newPage();
+  pageErrors = [];
+  page.on("pageerror", (err) => pageErrors.push(String(err)));
+  // Framework error handlers (Vue/Nuxt) can swallow the exception before it
+  // becomes an uncaught pageerror — capture console errors as well.
+  page.on("console", (msg) => {
+    if (msg.type() === "error") pageErrors.push(msg.text());
+  });
+  await page.goto("http://localhost:3001/teardown");
+  await new Promise((r) => setTimeout(r, 1000));
+});
+
+function touchEventProps(x: number, y: number, extra: object = {}) {
+  return {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    clientX: x,
+    clientY: y,
+    pointerId: 1,
+    pointerType: "touch",
+    ...extra,
+  };
+}
+
+test.describe("Teardown mid-interaction (#145)", async () => {
+  test("unmounting the list between pointerdown and pointermove does not throw", async () => {
+    // Press an item (touch), as if the user is about to drag.
+    await page.evaluate(() => {
+      const el = document.getElementById("Apple");
+      if (!el) throw new Error("missing item");
+      const rect = el.getBoundingClientRect();
+      el.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          button: 0,
+          buttons: 1,
+          clientX: rect.x + rect.width / 2,
+          clientY: rect.y + rect.height / 2,
+          pointerId: 1,
+          pointerType: "touch",
+        })
+      );
+    });
+
+    // The component unmounts mid-press (e.g. a route change or state-driven
+    // v-if). Programmatic click: a real pointer click would release the held
+    // pointer and end the interaction we're testing.
+    await page.locator("#toggle").evaluate((el) => (el as HTMLElement).click());
+    await expect(page.locator("#teardown_values")).toBeHidden();
+
+    // The held pointer moves: the document-level handler must not try to
+    // start a synthetic drag against the unmounted list.
+    await page.evaluate(() => {
+      document.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          buttons: 1,
+          clientX: 200,
+          clientY: 200,
+          pointerId: 1,
+          pointerType: "touch",
+        })
+      );
+    });
+    await new Promise((r) => setTimeout(r, 300));
+
+    expect(pageErrors).toEqual([]);
+
+    // Remounting yields a fully functional list again.
+    await page.locator("#toggle").evaluate((el) => (el as HTMLElement).click());
+    await expect(page.locator("#teardown_values")).toHaveText(
+      "Apple Banana Orange"
+    );
+    await syntheticDrag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      dragStart: true,
+      drop: true,
+    });
+    await expect(page.locator("#teardown_values")).toHaveText(
+      "Banana Apple Orange"
+    );
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -876,6 +876,24 @@ export function tearDown(parent: HTMLElement) {
 
   if (!parentData) return;
 
+  // Cancel interaction state tied to this parent so pending timers and the
+  // document-level drag handlers don't fire against unmounted elements
+  // (#145).
+  if (state.pointerDown?.parent.el === parent) {
+    if (state.longPressTimeout) clearTimeout(state.longPressTimeout);
+
+    state.pointerDown = undefined;
+  }
+
+  if (
+    isDragState(state) &&
+    (state.initialParent.el === parent || state.currentParent.el === parent)
+  ) {
+    if (isSynthDragState(state)) state.clonedDraggedNode?.remove();
+
+    resetState();
+  }
+
   if (parentData.abortControllers.mainParent)
     parentData.abortControllers.mainParent.abort();
 }
@@ -1690,7 +1708,9 @@ export function initDrag<T>(
 
         data.targetData.parent.el.appendChild(wrapper);
 
-        wrapper.showPopover();
+        // showPopover throws on disconnected elements (e.g. the parent was
+        // unmounted mid-interaction, #145).
+        if (wrapper.isConnected) wrapper.showPopover();
 
         wrapper.getBoundingClientRect(); // ← forces layout
 
@@ -2162,7 +2182,9 @@ function initSynthDrag<T>(
 
   parent.el.appendChild(dragImage);
 
-  dragImage.showPopover();
+  // showPopover throws on disconnected elements (e.g. the parent was
+  // unmounted mid-interaction, #145).
+  if (dragImage.isConnected) dragImage.showPopover();
 
   const synthDragStateProps = {
     clonedDraggedEls: [],

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -96,8 +96,13 @@ export function useDragAndDrop<E extends HTMLElement, T = unknown>(
   }, [values]);
 
   useEffect(() => {
+    // Capture the element now: React nulls DOM refs before passive effect
+    // cleanups run on unmount, so reading parent.current in the cleanup
+    // skipped tearDown entirely (#145).
+    const el = parent.current;
+
     return () => {
-      if (parent.current) tearDown(parent.current);
+      if (el) tearDown(el);
     };
   }, []);
 

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRef, Ref } from "vue";
 import type { VueDragAndDropData, VueParentConfig } from "./types";
 import { dragAndDrop as initParent, isBrowser, tearDown } from "../index";
-import { isRef, onUnmounted, ref, unref } from "vue";
+import { isRef, onBeforeUnmount, ref, unref } from "vue";
 import { handleVueElements } from "./utils";
 export * from "./types";
 
@@ -92,7 +92,9 @@ export function useDragAndDrop<T>(
 
   dragAndDrop({ parent, values, ...options });
 
-  onUnmounted(() => parent.value && tearDown(parent.value));
+  // onBeforeUnmount, not onUnmounted: template refs are already null by the
+  // time onUnmounted runs, so tearDown was never actually called (#145).
+  onBeforeUnmount(() => parent.value && tearDown(parent.value));
 
   return [parent, values, updateConfig];
 }

--- a/tests/components/TeardownList.vue
+++ b/tests/components/TeardownList.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { useDragAndDrop } from "../../src/vue/index";
+
+const [parent, values] = useDragAndDrop(["Apple", "Banana", "Orange"]);
+</script>
+
+<template>
+  <div>
+    <ul ref="parent" class="list">
+      <li v-for="value in values" :id="value" :key="value" class="item">
+        {{ value }}
+      </li>
+    </ul>
+    <span id="teardown_values">{{ values.join(" ") }}</span>
+  </div>
+</template>

--- a/tests/pages/teardown.vue
+++ b/tests/pages/teardown.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+const show = ref(true);
+</script>
+
+<template>
+  <div class="page-container">
+    <h1>Teardown mid-interaction</h1>
+    <button id="toggle" @click="show = !show">Toggle list</button>
+    <TeardownList v-if="show" />
+  </div>
+</template>


### PR DESCRIPTION
Fixes #145 (callbacks firing after unmount → `InvalidStateError: Failed to execute 'showPopover'… Invalid on disconnected popover elements`).

## What was actually wrong (three layers)
1. **The Vue adapter's tearDown never ran.** `onUnmounted(() => parent.value && tearDown(parent.value))` — template refs are nulled before `onUnmounted` fires, so the guard always short-circuited. Now `onBeforeUnmount`. **React had the same bug**: `parent.current` read inside the effect cleanup is already null on unmount; the element is now captured when the effect mounts. (Solid reads a signal, which survives — unchanged.)
2. **`tearDown` didn't cancel interaction state.** The drag handlers live on `document`, so after teardown a held pointer that moved still started a synthetic drag against the unmounted list — appending the drag image to a disconnected parent, where `showPopover()` throws exactly the reported error. `tearDown` now clears `pointerDown` + its long-press timer when they belong to the torn-down parent and resets in-flight drags involving it.
3. **Backstop**: both `showPopover` sites guard on `isConnected`.

## Tests
`tests/pages/teardown.vue` + `playwright/tests/drag/teardown.spec.ts`: press an item (touch), unmount the list **programmatically** (a real click would release the pointer and hide the bug — this matches route-change/state-driven unmounts), move the held pointer, assert zero page/console errors, then remount and complete a real drag. Red on unfixed code with the verbatim #145 error string.

Full suite: **142 passed, 0 failed** (all browsers + mobile).