### PR TITLE
feat(animations): support a configurable easing

### DIFF
--- a/playwright/tests/drag/animations-easing.spec.ts
+++ b/playwright/tests/drag/animations-easing.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect, Page } from "@playwright/test";
+import { drag } from "../../utils";
+
+let page: Page;
+
+test.beforeEach(async ({ browser }) => {
+  page = await browser.newPage();
+});
+
+test.describe("Animations plugin easing (#70)", async () => {
+  test("a configured easing is applied to sort animations", async () => {
+    await page.goto("http://localhost:3001/sort/animations-easing");
+    await new Promise((r) => setTimeout(r, 1000));
+
+    await drag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      dragStart: true,
+    });
+
+    // The 600ms animation is still running; read its timing.
+    const easing = await page.evaluate(() => {
+      for (const id of ["Apple", "Banana", "Orange"]) {
+        const animation = document.getElementById(id)?.getAnimations()[0];
+        if (animation)
+          return (animation.effect as KeyframeEffect).getTiming().easing;
+      }
+      return null;
+    });
+    expect(easing).toBe("cubic-bezier(0.22, 1, 0.36, 1)");
+
+    await expect(page.locator("#sort_values")).toHaveText(
+      "Banana Apple Orange"
+    );
+  });
+});

--- a/src/plugins/animations/index.ts
+++ b/src/plugins/animations/index.ts
@@ -53,22 +53,24 @@ export function animations(animationsConfig: Partial<AnimationsConfig> = {}) {
 
         const duration = animationsConfig.duration || 150;
 
+        const easing = animationsConfig.easing || "ease-in-out";
+
         if (data.node.data.value === state.draggedNode.data.value) {
           switch (state.incomingDirection) {
             case "below":
-              animate(data.node.el, slideUp, duration);
+              animate(data.node.el, slideUp, duration, easing);
 
               break;
             case "above":
-              animate(data.node.el, slideDown, duration);
+              animate(data.node.el, slideDown, duration, easing);
 
               break;
             case "left":
-              animate(data.node.el, slideRight, duration);
+              animate(data.node.el, slideRight, duration, easing);
 
               break;
             case "right":
-              animate(data.node.el, slideLeft, duration);
+              animate(data.node.el, slideLeft, duration, easing);
 
               break;
           }
@@ -115,26 +117,26 @@ export function animations(animationsConfig: Partial<AnimationsConfig> = {}) {
           );
 
           if (xDiff > yDiff && ascendingDirection) {
-            animate(data.node.el, slideRight, duration);
+            animate(data.node.el, slideRight, duration, easing);
           } else if (xDiff > yDiff && !ascendingDirection) {
-            animate(data.node.el, slideLeft, duration);
+            animate(data.node.el, slideLeft, duration, easing);
           }
         } else {
           switch (state.incomingDirection) {
             case "below":
-              animate(data.node.el, slideDown, duration);
+              animate(data.node.el, slideDown, duration, easing);
 
               break;
             case "above":
-              animate(data.node.el, slideUp, duration);
+              animate(data.node.el, slideUp, duration, easing);
 
               break;
             case "left":
-              animate(data.node.el, slideLeft, duration);
+              animate(data.node.el, slideLeft, duration, easing);
 
               break;
             case "right":
-              animate(data.node.el, slideRight, duration);
+              animate(data.node.el, slideRight, duration, easing);
 
               break;
           }
@@ -147,7 +149,8 @@ export function animations(animationsConfig: Partial<AnimationsConfig> = {}) {
 function animate(
   node: Node,
   animation: Keyframe[] | PropertyIndexedKeyframes,
-  duration: number
+  duration: number,
+  easing: string
 ) {
   if (!state) return;
 
@@ -155,7 +158,7 @@ function animate(
 
   node.animate(animation, {
     duration: duration,
-    easing: "ease-in-out",
+    easing,
   });
 
   setTimeout(() => {

--- a/src/plugins/animations/types.ts
+++ b/src/plugins/animations/types.ts
@@ -1,6 +1,12 @@
 import { ParentConfig } from "../../types";
 export interface AnimationsConfig {
   duration?: number;
+  /**
+   * CSS easing for the sort/transfer animations (any value accepted by the
+   * Web Animations API, e.g. "ease-in" or "cubic-bezier(0.22, 1, 0.36, 1)").
+   * Defaults to "ease-in-out".
+   */
+  easing?: string;
   remapFinished?: () => void;
   yScale?: number;
   xScale?: number;

--- a/tests/pages/sort/animations-easing.vue
+++ b/tests/pages/sort/animations-easing.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { useDragAndDrop } from "../../../src/vue/index";
+import { animations } from "../../../src/index";
+
+const [parent, values] = useDragAndDrop(["Apple", "Banana", "Orange"], {
+  plugins: [
+    animations({ duration: 600, easing: "cubic-bezier(0.22, 1, 0.36, 1)" }),
+  ],
+});
+</script>
+
+<template>
+  <div class="page-container">
+    <h1>Animations easing</h1>
+    <ul ref="parent" class="list">
+      <li v-for="value in values" :id="value" :key="value" class="item">
+        {{ value }}
+      </li>
+    </ul>
+    <div class="values">
+      Values:
+      <span id="sort_values">
+        {{ values.map((x) => x).join(" ") }}
+      </span>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Closes #70.

## What
`animations({ easing: "cubic-bezier(0.22, 1, 0.36, 1)" })` — any Web Animations API easing value, threaded through every `animate()` call in the plugin. Default unchanged (`ease-in-out`).

## Tests
New page + spec: starts a drag with a 600ms animation and reads `getAnimations()[0].effect.getTiming().easing` mid-flight, asserting the configured cubic-bezier (a value that can't false-positive against the default). Existing animation sort suites pass.