### PR TITLE
fix: preserve node identities when remapping during an active drag

### DIFF
--- a/playwright/tests-frameworks/deferred-sort.spec.ts
+++ b/playwright/tests-frameworks/deferred-sort.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, Page } from "@playwright/test";
+
+let page: Page;
+
+test.beforeAll(async ({ browser }) => {
+  page = await browser.newPage();
+  await page.goto("http://127.0.0.1:5173/");
+});
+
+/**
+ * Regression for #169: when framework commits lag behind the values array
+ * (React renders are async — Test4 defers its commits by 50ms), remapping
+ * mid-drag must not reassign node identities. Every registered node must
+ * keep the value it visibly renders; pairing values onto stale DOM
+ * positionally attaches wrong values/indices and corrupts subsequent sorts.
+ */
+test.describe("React deferred renders during drag (#169)", async () => {
+  test("node identities survive sorts while commits lag", async () => {
+    const id = "react_deferred_sort";
+
+    const result = await page.evaluate(async (id) => {
+      const mod = await import(
+        /* @vite-ignore */
+        "/@fs/" +
+          // eslint-disable-next-line no-useless-concat
+          "Users/justinschroeder/Projects/formkit-coordinator/.dmux/worktrees/drag-drop-review/drag-and-drop/src/index.ts"
+      );
+
+      const byId = (v: string) => document.getElementById(`${id}_${v}`)!;
+      const dataTransfer = new DataTransfer();
+      const props = (el: Element) => {
+        const rect = el.getBoundingClientRect();
+        return {
+          bubbles: true,
+          cancelable: true,
+          clientX: rect.x + rect.width / 2,
+          clientY: rect.y + rect.height / 2,
+          dataTransfer,
+        };
+      };
+
+      const probe = () =>
+        Array.from(
+          document.querySelectorAll(`#${id} .item`)
+        ).map((el) => ({
+          rendered: (el.textContent ?? "").trim(),
+          registered: mod.nodes.get(el)?.value ?? null,
+        }));
+
+      // Keep the list away from the viewport edges: dragovers near an edge
+      // engage auto-scroll, which sets preventEnter and swallows sorts.
+      document.getElementById(id)!.scrollIntoView({ block: "center" });
+      await new Promise((r) => setTimeout(r, 200));
+
+      const dragged = byId("one");
+      dragged.dispatchEvent(new DragEvent("dragstart", props(dragged)));
+      // Wait out the preventEnter window that follows dragstart.
+      await new Promise((r) => setTimeout(r, 250));
+
+      // Sort #1: values update immediately, the commit lands 50ms later.
+      const t1 = byId("three");
+      t1.dispatchEvent(new DragEvent("dragover", props(t1)));
+      t1.dispatchEvent(new DragEvent("dragover", props(t1)));
+
+      // Sort #2 races the pending commit: the remap inside performSort runs
+      // against stale DOM.
+      await new Promise((r) => setTimeout(r, 20));
+      const t2 = byId("five");
+      t2.dispatchEvent(new DragEvent("dragover", props(t2)));
+      t2.dispatchEvent(new DragEvent("dragover", props(t2)));
+
+      // Inspect node identities inside the mispair window, before the
+      // deferred commit re-syncs the DOM.
+      const midDrag = probe();
+
+      // Finish the drag and let all commits settle.
+      const last = byId("five");
+      last.dispatchEvent(new DragEvent("drop", props(last)));
+      document.dispatchEvent(new DragEvent("dragend", props(last)));
+      await new Promise((r) => setTimeout(r, 600));
+
+      const settled = probe();
+
+      const values =
+        document.getElementById(`${id}_values`)?.textContent ?? "";
+
+      return { midDrag, settled, values };
+    }, id);
+
+    // The invariant under test: a node never carries a value other than
+    // the one it renders, even while the DOM lags the values array.
+    for (const { rendered, registered } of result.midDrag) {
+      expect(registered).toBe(rendered);
+    }
+    for (const { rendered, registered } of result.settled) {
+      expect(registered).toBe(rendered);
+    }
+
+    // And the drag itself lands where the user hovered last.
+    expect(result.values).toBe("two three four five one");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1218,12 +1218,58 @@ export function remapNodes<T>(parent: HTMLElement, force?: boolean) {
 
   const enabledNodeRecords: Array<NodeRecord<T>> = [];
 
+  // During an active drag the DOM can lag behind the values array, because
+  // framework renders are asynchronous (React especially, #169). Pairing
+  // values to nodes positionally would then reassign node identities —
+  // attaching the wrong value/index to elements and corrupting every
+  // subsequent sort. While dragging, pair each known node to its existing
+  // value instead and derive its index from the values array. Falls back to
+  // positional pairing whenever existing node values can't be matched 1:1
+  // onto the current values (initial setup, transfers committing, replaced
+  // arrays).
+  let identityIndexes: Array<number> | null = null;
+
+  if (isDragState(state)) {
+    identityIndexes = [];
+
+    const consumed = new Array(values.length).fill(false);
+
+    for (let x = 0; x < enabledNodes.length; x++) {
+      const prevNodeData = nodes.get(enabledNodes[x]);
+
+      let found = -1;
+
+      if (prevNodeData) {
+        for (let i = 0; i < values.length; i++) {
+          if (!consumed[i] && eq(values[i], prevNodeData.value)) {
+            found = i;
+
+            break;
+          }
+        }
+      }
+
+      if (found === -1) {
+        identityIndexes = null;
+
+        break;
+      }
+
+      consumed[found] = true;
+
+      identityIndexes.push(found);
+    }
+  }
+
   for (let x = 0; x < enabledNodes.length; x++) {
     const node = enabledNodes[x];
 
     const prevNodeData = nodes.get(node);
 
-    if (config.draggableValue && !config.draggableValue(values[x])) continue;
+    const valueIndex = identityIndexes ? identityIndexes[x] : x;
+
+    if (config.draggableValue && !config.draggableValue(values[valueIndex]))
+      continue;
 
     const nodeData = Object.assign(
       prevNodeData ?? {
@@ -1231,8 +1277,8 @@ export function remapNodes<T>(parent: HTMLElement, force?: boolean) {
         abortControllers: {},
       },
       {
-        value: values[x],
-        index: x,
+        value: values[valueIndex],
+        index: valueIndex,
       }
     );
 

--- a/tests-frameworks/react/App.tsx
+++ b/tests-frameworks/react/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Test1 from "./components/Test1";
 import Test2 from "./components/Test2";
+import Test4 from "./components/Test4";
 import reactLogo from "/reactjs-icon.svg";
 
 const App: React.FC = () => {
@@ -13,6 +14,8 @@ const App: React.FC = () => {
         <Test1 id="react_drag_and_drop" testDescription="dragAndDrop" />
         <div className="divider"></div>
         <Test2 id="react_use_drag_and_drop" testDescription="useDragAndDrop" />
+        <div className="divider"></div>
+        <Test4 id="react_deferred_sort" testDescription="deferred renders" />
       </div>
     </>
   );

--- a/tests-frameworks/react/components/Test4.tsx
+++ b/tests-frameworks/react/components/Test4.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+import { useState, useEffect, useRef } from "react";
+
+import { dragAndDrop } from "../../../src/react/index";
+
+/**
+ * Regression component for #169: state updates are committed in a
+ * transition, so the DOM lags behind the values array the way a slow
+ * React render does. Rapid drags must not scramble node identities.
+ */
+function Test4(props: { id: string; testDescription: string }) {
+  const [values, setValues] = useState(["one", "two", "three", "four", "five"]);
+
+  const parent = useRef(null);
+
+  useEffect(() => {
+    dragAndDrop<HTMLUListElement, string>({
+      parent,
+      state: [
+        values,
+        // Commit to React 50ms late: the adapter's value store updates
+        // synchronously while the DOM lags behind, the way a slow React
+        // render does in real apps (#169).
+        (newValues) =>
+          setTimeout(
+            () => setValues(newValues as React.SetStateAction<string[]>),
+            50
+          ),
+      ],
+    });
+  }, [values]);
+
+  return (
+    <>
+      <h3>#{props.id}</h3>
+      <h4>{props.testDescription}</h4>
+      <ul id={props.id} ref={parent}>
+        {values.map((value) => (
+          <li className="item" key={value} id={props.id + "_" + value}>
+            {value}
+          </li>
+        ))}
+      </ul>
+      <span id={props.id + "_values"}>{values.join(" ")}</span>
+    </>
+  );
+}
+
+export default Test4;


### PR DESCRIPTION
Fixes #169 — excellent diagnosis by @winston-lau (the issue's analysis of `remapNodes` pairing `values[x]` to `enabledNodes[x]` positionally while React's commits lag is exactly right).

## Bug
During a drag, every remap (MutationObserver-driven *and* the one inside `performSort`) paired values to DOM children by position. When the DOM lags the values array — React under load, transitions, slow rows — the pairing reassigns node identities: elements get values they don't render, `state.draggedNode` gets re-pointed at a **different element**, and subsequent sorts splice at wrong indices. The corruption compounds drag over drag.

## Fix (differs from the issue's proposed patch)
The issue proposed skipping `remapNodes` in `nodesMutated` mid-drag, but flagged the transfer problem themselves — and `performSort`'s own remap has the same race anyway. Instead, **remap becomes identity-preserving while a drag is active**: each known node keeps its existing value and derives its index from the current values array (consumed-slot matching keeps duplicates 1:1). When existing node values can't be matched 1:1 onto the current values — initial setup, transfers mid-commit, wholesale value replacement — it falls back to positional pairing, i.e. previous behavior. Outside of drags nothing changes at all.

This makes mid-drag remaps order-insensitive: stale DOM and fresh DOM both produce correct indices, and the dragged element can never be swapped out from under the drag.

## Tests
New React test component (`Test4`) defers its commits by 50ms — the adapter's value store updates synchronously while the DOM lags, the same shape as a slow render. The spec performs two sorts inside the lag window and asserts the invariant that actually breaks userland: **a registered node never carries a value other than the one it renders** (checked via the module's `nodes` WeakMap mid-drag), plus the drag landing where the user last hovered.
- **Red on unfixed code**: the probe catches an element rendering `one` registered as `two`.
- Green with the fix, including the settled assertions.

Full suite: **148 passed, 0 failed** (Chrome/Firefox/WebKit + mobile — covers sorts, transfers, plugins, multidrag on the new remap).