### PR TITLE
fix(docs): render all code example languages at build time

### DIFF
--- a/docs/components/CodeExample.vue
+++ b/docs/components/CodeExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { Component } from "vue";
-import { shallowRef, ref, reactive, watch, onMounted, nextTick } from "vue";
+import { shallowRef, ref, watch, onMounted } from "vue";
 import IconMarko from "./IconMarko.vue";
 
 const props = defineProps<{
@@ -15,12 +15,10 @@ const availableLangs = ["react", "vue", "solid", "native", "marko"];
 const copyButtonRef = ref<HTMLButtonElement | null>(null);
 
 const cmp = shallowRef<Component | false>(false);
-const loadedLangs = reactive(new Set(["react"]));
 
 watch(
   exampleLang,
   (newLang) => {
-    loadedLangs.add(newLang);
     rawCode.value = codeCache.value[newLang] || "";
     copyStatus.value = rawCode.value ? "Copy" : "Error";
   },
@@ -195,19 +193,25 @@ async function copyCode() {
       v-show="expanded"
       class="editor border-l-4 border-r-4 border-slate-400 dark:border-slate-500"
     >
-      <div v-if="loadedLangs.has('react')" v-show="exampleLang === 'react'">
+      <!--
+        All panes render during SSR/SSG and toggle with v-show. They are
+        server components: mounting them lazily on tab click requires a
+        runtime island request, which has no server to answer it on the
+        statically deployed site — tabs came back empty (#174).
+      -->
+      <div v-show="exampleLang === 'react'">
         <CodeExampleReact :example="example" />
       </div>
-      <div v-if="loadedLangs.has('vue')" v-show="exampleLang === 'vue'">
+      <div v-show="exampleLang === 'vue'">
         <CodeExampleVue :example="example" />
       </div>
-      <div v-if="loadedLangs.has('solid')" v-show="exampleLang === 'solid'">
+      <div v-show="exampleLang === 'solid'">
         <CodeExampleSolid :example="example" />
       </div>
-      <div v-if="loadedLangs.has('native')" v-show="exampleLang === 'native'">
+      <div v-show="exampleLang === 'native'">
         <CodeExampleNative :example="example" />
       </div>
-      <div v-if="loadedLangs.has('marko')" v-show="exampleLang === 'marko'">
+      <div v-show="exampleLang === 'marko'">
         <CodeExampleMarko :example="example" />
       </div>
     </div>

--- a/docs/examples/config/config.ts
+++ b/docs/examples/config/config.ts
@@ -348,17 +348,17 @@ export interface ParentConfig<T> {
   /**
    * Callback function for when a sort operation is performed.
    */
-  onSort?: SortEvent;
+  onSort?: SortEvent<T>;
   /**
    * Callback function for when a transfer operation is performed.
    */
-  onTransfer?: TransferEvent;
+  onTransfer?: TransferEvent<T>;
   /**
    * Fired when a drag is started, whether native drag or synthetic
    */
-  onDragstart?: DragstartEvent;
+  onDragstart?: DragstartEvent<T>;
   /**
    * Fired when a drag is ended, whether native drag or synthetic
    */
-  onDragend?: DragendEvent;
+  onDragend?: DragendEvent<T>;
 }


### PR DESCRIPTION
Fixes #174 (only the React tab renders on drag-and-drop.formkit.com).

## Root cause — two layers
1. The Vue/Solid/Native/Marko panes are **server components** mounted lazily (`v-if` on first tab click). On the statically deployed site, that mount issues a runtime `/__nuxt_island/...` request with no server to answer it → empty pane.
2. Eagerly prerendering them surfaced a second bug the lazy islands had been hiding: `docs/examples/config/config.ts` mirrors `ParentConfig` and still used the unparameterized handler types — after #186 that's TS2314, twoslash rejects the sample, and the Native island 500s **even with a server**. This is consistent with the issue reporting all non-React tabs blank.

## Fix
- All five panes render during SSG and toggle with `v-show`. The highlighted HTML ships in the static page; the client-perf win of server components (no shiki/twoslash on the client) is preserved — the cost moves to build time.
- `config.ts` example updated to `SortEvent<T>` et al.

## Verification
- `nuxt generate` completes with **zero prerender errors** (71 island routes), where it previously failed.
- Generated `index.html` contains the raw-code containers and shiki output for **all five languages** (774 highlighted blocks).
- Copy button now works for every tab immediately (raw-code containers all present at load).