### PR TITLE
ci: cache Playwright browsers and bound the install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,28 @@ jobs:
         run: cd tests-frameworks && pnpm install && cd ..
       - name: Build Dev
         run: cd tests && pnpm install && cd ..
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ matrix.browser }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright
-        run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
+        # The browser download intermittently stalls forever (no output after
+        # reaching the CDN), which used to eat the whole job timeout. Bound
+        # each attempt and retry instead of hanging.
+        timeout-minutes: 20
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 300 pnpm exec playwright install --with-deps ${{ matrix.browser }}; then
+              exit 0
+            fi
+            echo "playwright install stalled or failed (attempt $attempt), retrying..."
+            sleep 5
+          done
+          exit 1
       - name: Run Playwright tests
         run: pnpm exec playwright test --project "${{ matrix.project }}"
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
Second half of the CI-timeout fix (with #193).

## Diagnosis
Job logs show every recent "cancelled" run — single-job **and** sharded — died the same way: `playwright install` starts the Chromium download from `cdn.playwright.dev` (already the fallback CDN) and then produces **no further output for the rest of the job** until `timeout-minutes: 30` kills it. The tests never started; the suite itself was never the problem.

## Fix
- `actions/cache` on `~/.cache/ms-playwright` keyed by browser + Playwright version: warm runs skip the download entirely.
- The install step is bounded: `timeout 300` per attempt, 3 attempts, so a stalled download costs at most ~5 minutes before retrying instead of eating the job.

The run triggered by this merge validates the full pipeline end to end.