### PR TITLE
ci: pin Node to 24.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
-          check-latest: true
+          # Pinned: Node 24.16.0 hangs Playwright's browser download at 100%
+          # (stream never finalizes). 24.15.0 is the last verified-good
+          # version on these runners — bump deliberately, with a green run.
+          node-version: 24.15.0
       - name: Update npm
         run: npm install -g npm@latest
       - name: Verify runtime


### PR DESCRIPTION
Final piece of the CI fix (with #193 sharding and #195 install bounding).

## Diagnosis
With #195's bounded retries, the stall became observable: **every** browser download (chromium/firefox/webkit), every attempt, reaches 100% and never finalizes. Comparing runtimes:
- last green run (Apr 30): **Node v24.15.0**
- all hanging runs (today): **Node v24.16.0** — pulled in by `check-latest: true`

Same workflow, same Playwright, same CDN — the only delta is the Node patch version. 24.16.0 has a stream-finalization regression that Playwright's downloader trips over.

## Fix
Pin `node-version: 24.15.0` and drop `check-latest` — future bumps should be deliberate, verified by a green run. The #195 retry bound stays as a safety net (a genuine CDN stall now costs minutes, not the job).

The run triggered by this merge is the end-to-end validation.