### PR TITLE
test: run the Desktop Webkit project on actual WebKit

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -48,7 +48,10 @@ export default defineConfig({
       testMatch: ["tests/drag/**/*.spec.ts", "tests-frameworks/**/*.spec.ts"],
 
       use: {
-        ...devices["Desktop Webkit"],
+        // "Desktop Webkit" is not a registered device descriptor — spreading
+        // it was undefined, so this project silently ran on the default
+        // browser (chromium). "Desktop Safari" is the real WebKit device.
+        ...devices["Desktop Safari"],
       },
     },
     {


### PR DESCRIPTION
Fixes the WebKit shard failures from the last run — and a latent gap the sharding exposed.

## What was wrong
`devices["Desktop Webkit"]` is **not** a Playwright device descriptor (`Desktop Safari` is). Spreading `undefined` left the project on the default browser, so "Desktop Webkit" has been running on **chromium** since it was introduced. Locally that was invisible (chromium always installed); the webkit-only CI shard made it loud: every test failed at launch wanting `chromium_headless_shell`.

## Fix
`devices["Desktop Safari"]` — the real WebKit descriptor.

## The good news
The full suite **passes on actual WebKit locally (46/46)** — the library was fine on WebKit; it just had zero genuine WebKit coverage until now. The run triggered by this merge should be the first fully green CI on the branch.