### PR TITLE
fix(handler): fix focusable elements double-click to activate drag

### DIFF
--- a/docs/examples/config/config.ts
+++ b/docs/examples/config/config.ts
@@ -66,6 +66,11 @@ export interface ParentConfig<T> {
    */
   dragHandle?: string;
   /**
+   * A selector for elements that should not activate dragging. Matching
+   * elements and their descendants remain interactive.
+   */
+  dragIgnore?: string;
+  /**
    * External drag handle
    */
   externalDragHandle?: {

--- a/playwright/tests/drag/drag-ignore.spec.ts
+++ b/playwright/tests/drag/drag-ignore.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+import { drag } from "../../utils";
+
+test("ignored elements do not activate native dragging", async ({ page }) => {
+  await page.goto("http://localhost:3001/drag-ignore");
+
+  await drag(page, {
+    originEl: { id: "Apple_ignore_child", position: "center" },
+    destinationEl: { id: "Banana", position: "center" },
+    dragStart: true,
+  });
+
+  await expect(page.locator("#drag_ignore_values")).toHaveText(
+    "Apple Banana Orange"
+  );
+
+  await drag(page, {
+    originEl: { id: "Apple", position: "left" },
+    destinationEl: { id: "Banana", position: "center" },
+    dragStart: true,
+  });
+
+  await expect(page.locator("#drag_ignore_values")).toHaveText(
+    "Banana Apple Orange"
+  );
+});

--- a/playwright/tests/drag/draghandle.spec.ts
+++ b/playwright/tests/drag/draghandle.spec.ts
@@ -8,6 +8,56 @@ test.beforeEach(async ({ browser }) => {
 });
 
 test.describe("Native drag with drag handles", async () => {
+  test("Focused button handles enable dragging on the first pointerdown", async () => {
+    await page.goto("http://localhost:3001/draghandle");
+
+    const handle = page.locator("#Apple_dragHandle");
+    const item = page.locator("#Apple");
+    const box = await handle.boundingBox();
+
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+
+    await expect(handle).toBeFocused();
+    await expect(item).toHaveAttribute("draggable", "true");
+
+    await page.mouse.up();
+  });
+
+  for (const target of [
+    {
+      name: "nested non-handle target",
+      childId: "Apple_nonHandle_child",
+      buttonId: "Apple_nonHandle",
+    },
+    {
+      name: "nested ignored target",
+      childId: "Apple_dragIgnore_child",
+      buttonId: "Apple_dragIgnore",
+    },
+  ]) {
+    test(`Focused ${target.name} keeps dragging disabled`, async () => {
+      await page.goto("http://localhost:3001/draghandle");
+
+      const child = page.locator(`#${target.childId}`);
+      const button = page.locator(`#${target.buttonId}`);
+      const item = page.locator("#Apple");
+      const box = await child.boundingBox();
+
+      expect(box).not.toBeNull();
+
+      await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+      await page.mouse.down();
+
+      await expect(button).toBeFocused();
+      await expect(item).toHaveAttribute("draggable", "false");
+
+      await page.mouse.up();
+    });
+  }
+
   test("Native drag with drag handles. Should not be able to pick up item unless using drag handle", async () => {
     await page.goto("http://localhost:3001/draghandle");
     await new Promise((r) => setTimeout(r, 1000));

--- a/playwright/tests/synthetic-drag/drag-ignore.spec.ts
+++ b/playwright/tests/synthetic-drag/drag-ignore.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { syntheticDrag } from "../../utils";
+
+test("ignored elements do not activate synthetic dragging", async ({
+  page,
+}) => {
+  await page.goto("http://localhost:3001/drag-ignore");
+
+  await syntheticDrag(page, {
+    originEl: { id: "Apple_ignore_child", position: "center" },
+    destinationEl: { id: "Banana", position: "center" },
+    dragStart: true,
+  });
+
+  await expect(page.locator("#drag_ignore_values")).toHaveText(
+    "Apple Banana Orange"
+  );
+
+  await syntheticDrag(page, {
+    originEl: { id: "Apple", position: "left" },
+    destinationEl: { id: "Banana", position: "center" },
+    dragStart: true,
+  });
+
+  await expect(page.locator("#drag_ignore_values")).toHaveText(
+    "Banana Apple Orange"
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1442,7 +1442,7 @@ export function handleDragstart<T>(
   const validated =
     state.pointerDown && state.pointerDown.node.el === data.targetData.node.el
       ? state.pointerDown.validated
-      : validateDragHandle({
+      : validateDragActivation({
           e: data.e,
           node: data.targetData.node,
           config,
@@ -1504,7 +1504,7 @@ export function handleNodePointerdown<T>(
   };
 
   if (
-    !validateDragHandle({
+    !validateDragActivation({
       e: data.e,
       node: data.targetData.node,
       config: data.targetData.parent.data.config,
@@ -1817,6 +1817,52 @@ export function validateDragHandle<T>({
     if (elFromPoint === handle || handle.contains(elFromPoint)) return true;
 
   return false;
+}
+
+export function isDragIgnored<T>({
+  e,
+  node,
+  config,
+}: {
+  e: PointerEvent | DragEvent;
+  node: NodeRecord<T>;
+  config: ParentConfig<T>;
+}): boolean {
+  if (!config.dragIgnore) return false;
+
+  const path = e.composedPath();
+
+  const nodeIndex = path.indexOf(node.el);
+
+  const pathToNode = nodeIndex === -1 ? [] : path.slice(0, nodeIndex + 1);
+
+  for (const target of pathToNode) {
+    if (target instanceof Element && target.matches(config.dragIgnore))
+      return true;
+  }
+
+  const elFromPoint = config.root.elementFromPoint(e.clientX, e.clientY);
+
+  if (!elFromPoint || !node.el.contains(elFromPoint)) return false;
+
+  const ignoredElement = elFromPoint.closest(config.dragIgnore);
+
+  return !!ignoredElement && node.el.contains(ignoredElement);
+}
+
+function validateDragActivation<T>({
+  e,
+  node,
+  config,
+}: {
+  e: PointerEvent | DragEvent;
+  node: NodeRecord<T>;
+  config: ParentConfig<T>;
+}): boolean {
+  return (
+    !isDragIgnored({ e, node, config }) &&
+    validateDragHandle({ e, node, config })
+  );
 }
 
 export function handleClickNode<T>(_data: NodeEventData<T>) {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1929,7 +1929,14 @@ export function handleNodeDrop<T>(
 export function handleNodeFocus<T>(data: NodeEventData<T>) {
   if (data.e.target === data.e.currentTarget) return;
 
-  if (state.pointerDown) state.pointerDown.node.el.draggable = false;
+  if (!state.pointerDown) return;
+
+  const pointerDown = state.pointerDown;
+  const isValidatedDragActivation =
+    pointerDown.validated &&
+    pointerDown.node.el === data.targetData.node.el;
+
+  if (!isValidatedDragActivation) pointerDown.node.el.draggable = false;
 }
 
 export function handleNodeBlur<T>(data: NodeEventData<T>) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,11 @@ export interface ParentConfig<T> {
    */
   dragHandle?: string;
   /**
+   * A selector for elements that should not activate dragging. Matching
+   * elements and their descendants remain interactive.
+   */
+  dragIgnore?: string;
+  /**
    * External drag handle
    */
   externalDragHandle?: {

--- a/tests/pages/drag-ignore.vue
+++ b/tests/pages/drag-ignore.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { useDragAndDrop } from "../../src/vue/index";
+
+const [parent, values] = useDragAndDrop(["Apple", "Banana", "Orange"], {
+  dragIgnore: ".drag-ignore",
+});
+</script>
+
+<template>
+  <ul ref="parent">
+    <li class="item" v-for="value in values" :id="value" :key="value">
+      <span>{{ value }}</span>
+      <button :id="`${value}_ignore`" class="drag-ignore" type="button">
+        <span :id="`${value}_ignore_child`">Ignore drag</span>
+      </button>
+    </li>
+  </ul>
+  <span id="drag_ignore_values">{{ values.join(" ") }}</span>
+</template>
+
+<style scoped>
+.item {
+  cursor: grab;
+}
+
+.drag-ignore {
+  border: 1px dashed #435;
+  cursor: pointer;
+}
+</style>

--- a/tests/pages/dragHandle/index.vue
+++ b/tests/pages/dragHandle/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useDragAndDrop } from "../../../src/vue/index";
 
-const [parent1, values1] = useDragAndDrop(["Apple", "Banana", "Orange"], {
+const [parent1, values1] = useDragAndDrop<string>(["Apple", "Banana", "Orange"], {
   group: "transfer",
   draggable: (el) => {
     return el.tagName === "LI";
@@ -9,9 +9,10 @@ const [parent1, values1] = useDragAndDrop(["Apple", "Banana", "Orange"], {
   dropZoneClass: "dropZone",
   synthDropZoneClass: "synthDropZone",
   dragHandle: ".dragHandle",
+  dragIgnore: ".dragIgnore",
 });
 
-const [parent2, values2] = useDragAndDrop(["Cherry", "Grape", "Pineapple"], {
+const [parent2, values2] = useDragAndDrop<string>(["Cherry", "Grape", "Pineapple"], {
   group: "transfer",
   draggable: (el) => {
     return el.tagName === "LI";
@@ -47,14 +48,28 @@ function click() {
       <ul id="transfer_1" ref="parent1" class="list" aria-label="list1">
         <li v-for="value in values1" :id="value" :key="value" class="item">
           <div class="item-content">
-            <span :id="value + '_dragHandle'" class="dragHandle">
+            <button
+              :id="value + '_dragHandle'"
+              class="dragHandle"
+              type="button"
+            >
               <svg viewBox="0 0 24 24" width="24" height="24">
                 <path
                   fill="currentColor"
                   d="M9,3H11V5H9V3M13,3H15V5H13V3M9,7H11V9H9V7M13,7H15V9H13V7M9,11H11V13H9V11M13,11H15V13H13V11M9,15H11V17H9V15M13,15H15V17H13V15M9,19H11V21H9V19M13,19H15V21H13V19Z"
                 />
               </svg>
-            </span>
+            </button>
+            <button :id="value + '_nonHandle'" type="button">
+              <span :id="value + '_nonHandle_child'">Edit</span>
+            </button>
+            <button
+              :id="value + '_dragIgnore'"
+              class="dragIgnore"
+              type="button"
+            >
+              <span :id="value + '_dragIgnore_child'">Ignore</span>
+            </button>
             <span class="item-text">{{ value }}</span>
           </div>
         </li>


### PR DESCRIPTION
PR contains 2 commits.
1. First one introduces new `dragIgnore` property, which allows to ignore some elements under `dragHandle`
2. Second fixes bug when dragHandle is any focusable el(for example button). Button is focusable and when you click it sets `draggable=true` in **pointerdown** event after validations are passed and `draggable=faslse` in **focus** event. I've added check If element is valid and not ignored **focus** event  doesn't apply `draggable=false` 