### PR TITLE
feat(handler): add prop to ignore drag activation

### DIFF
--- a/docs/examples/config/config.ts
+++ b/docs/examples/config/config.ts
@@ -66,6 +66,11 @@ export interface ParentConfig<T> {
    */
   dragHandle?: string;
   /**
+   * A selector for elements that should not activate dragging. Matching
+   * elements and their descendants remain interactive.
+   */
+  dragIgnore?: string;
+  /**
    * External drag handle
    */
   externalDragHandle?: {

--- a/playwright/tests/drag/drag-ignore.spec.ts
+++ b/playwright/tests/drag/drag-ignore.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+import { drag } from "../../utils";
+
+test("ignored elements do not activate native dragging", async ({ page }) => {
+  await page.goto("http://localhost:3001/drag-ignore");
+
+  await drag(page, {
+    originEl: { id: "Apple_ignore_child", position: "center" },
+    destinationEl: { id: "Banana", position: "center" },
+    dragStart: true,
+  });
+
+  await expect(page.locator("#drag_ignore_values")).toHaveText(
+    "Apple Banana Orange"
+  );
+
+  await drag(page, {
+    originEl: { id: "Apple", position: "left" },
+    destinationEl: { id: "Banana", position: "center" },
+    dragStart: true,
+  });
+
+  await expect(page.locator("#drag_ignore_values")).toHaveText(
+    "Banana Apple Orange"
+  );
+});

--- a/playwright/tests/synthetic-drag/drag-ignore.spec.ts
+++ b/playwright/tests/synthetic-drag/drag-ignore.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { syntheticDrag } from "../../utils";
+
+test("ignored elements do not activate synthetic dragging", async ({
+  page,
+}) => {
+  await page.goto("http://localhost:3001/drag-ignore");
+
+  await syntheticDrag(page, {
+    originEl: { id: "Apple_ignore_child", position: "center" },
+    destinationEl: { id: "Banana", position: "center" },
+    dragStart: true,
+  });
+
+  await expect(page.locator("#drag_ignore_values")).toHaveText(
+    "Apple Banana Orange"
+  );
+
+  await syntheticDrag(page, {
+    originEl: { id: "Apple", position: "left" },
+    destinationEl: { id: "Banana", position: "center" },
+    dragStart: true,
+  });
+
+  await expect(page.locator("#drag_ignore_values")).toHaveText(
+    "Banana Apple Orange"
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1442,7 +1442,7 @@ export function handleDragstart<T>(
   const validated =
     state.pointerDown && state.pointerDown.node.el === data.targetData.node.el
       ? state.pointerDown.validated
-      : validateDragHandle({
+      : validateDragActivation({
           e: data.e,
           node: data.targetData.node,
           config,
@@ -1504,7 +1504,7 @@ export function handleNodePointerdown<T>(
   };
 
   if (
-    !validateDragHandle({
+    !validateDragActivation({
       e: data.e,
       node: data.targetData.node,
       config: data.targetData.parent.data.config,
@@ -1817,6 +1817,52 @@ export function validateDragHandle<T>({
     if (elFromPoint === handle || handle.contains(elFromPoint)) return true;
 
   return false;
+}
+
+export function isDragIgnored<T>({
+  e,
+  node,
+  config,
+}: {
+  e: PointerEvent | DragEvent;
+  node: NodeRecord<T>;
+  config: ParentConfig<T>;
+}): boolean {
+  if (!config.dragIgnore) return false;
+
+  const path = e.composedPath();
+
+  const nodeIndex = path.indexOf(node.el);
+
+  const pathToNode = nodeIndex === -1 ? [] : path.slice(0, nodeIndex + 1);
+
+  for (const target of pathToNode) {
+    if (target instanceof Element && target.matches(config.dragIgnore))
+      return true;
+  }
+
+  const elFromPoint = config.root.elementFromPoint(e.clientX, e.clientY);
+
+  if (!elFromPoint || !node.el.contains(elFromPoint)) return false;
+
+  const ignoredElement = elFromPoint.closest(config.dragIgnore);
+
+  return !!ignoredElement && node.el.contains(ignoredElement);
+}
+
+function validateDragActivation<T>({
+  e,
+  node,
+  config,
+}: {
+  e: PointerEvent | DragEvent;
+  node: NodeRecord<T>;
+  config: ParentConfig<T>;
+}): boolean {
+  return (
+    !isDragIgnored({ e, node, config }) &&
+    validateDragHandle({ e, node, config })
+  );
 }
 
 export function handleClickNode<T>(_data: NodeEventData<T>) {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,11 @@ export interface ParentConfig<T> {
    */
   dragHandle?: string;
   /**
+   * A selector for elements that should not activate dragging. Matching
+   * elements and their descendants remain interactive.
+   */
+  dragIgnore?: string;
+  /**
    * External drag handle
    */
   externalDragHandle?: {

--- a/tests/pages/drag-ignore.vue
+++ b/tests/pages/drag-ignore.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { useDragAndDrop } from "../../src/vue/index";
+
+const [parent, values] = useDragAndDrop(["Apple", "Banana", "Orange"], {
+  dragIgnore: ".drag-ignore",
+});
+</script>
+
+<template>
+  <ul ref="parent">
+    <li class="item" v-for="value in values" :id="value" :key="value">
+      <span>{{ value }}</span>
+      <button :id="`${value}_ignore`" class="drag-ignore" type="button">
+        <span :id="`${value}_ignore_child`">Ignore drag</span>
+      </button>
+    </li>
+  </ul>
+  <span id="drag_ignore_values">{{ values.join(" ") }}</span>
+</template>
+
+<style scoped>
+.item {
+  cursor: grab;
+}
+
+.drag-ignore {
+  border: 1px dashed #435;
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
Introduces new `dragIgnore` property, which allows to ignore some elements under `dragHandle`