### PR TITLE
fix(core): emit onDragstart for synthetic drag starts

### DIFF
--- a/playwright/tests/synthetic-drag/events.spec.ts
+++ b/playwright/tests/synthetic-drag/events.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect, Page } from "@playwright/test";
+import { syntheticDrag } from "../../utils";
+
+let page: Page;
+
+test.beforeEach(async ({ browser }) => {
+  page = await browser.newPage();
+});
+
+test.describe("Synthetic drag events", async () => {
+  test("onDragstart callback fires when synth drag starts", async () => {
+    await page.goto("http://localhost:3001/synthetic-drag-events");
+    await new Promise((r) => setTimeout(r, 1000));
+
+    await syntheticDrag(page, {
+      originEl: { id: "Apple", position: "center" },
+      destinationEl: { id: "Banana", position: "center" },
+      dragStart: true,
+    });
+
+    await expect(page.locator("#dragstart_count")).toHaveText("1");
+    await expect(page.locator("#dragstart_value")).toHaveText("Apple");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -332,6 +332,8 @@ function handleRootPointermove(e: PointerEvent) {
       rect
     );
 
+    emitOnDragstart(state.pointerDown.parent, synthDragState, config);
+
     synthMove(e, synthDragState, true);
   } else if (isSynthDragState(state)) {
     synthMove(e, state);
@@ -1387,20 +1389,26 @@ export function handleDragstart<T>(
 
   const dragState = initDrag(data, nodes);
 
-  if (config.onDragstart) {
-    const dragstartData: DragstartEventData<T> = {
-      parent: data.targetData.parent,
-      values: parentValues(
-        data.targetData.parent.el,
-        data.targetData.parent.data
-      ),
-      draggedNode: dragState.draggedNode,
-      draggedNodes: dragState.draggedNodes,
-      position: dragState.initialIndex,
-      state: dragState,
-    };
-    config.onDragstart(dragstartData);
-  }
+  emitOnDragstart(data.targetData.parent, dragState, config);
+}
+
+function emitOnDragstart<T>(
+  parent: ParentRecord<T>,
+  dragState: DragState<T> | SynthDragState<T>,
+  config: ParentConfig<T>
+) {
+  if (!config.onDragstart) return;
+
+  const dragstartData: DragstartEventData<T> = {
+    parent,
+    values: parentValues(parent.el, parent.data),
+    draggedNode: dragState.draggedNode,
+    draggedNodes: dragState.draggedNodes,
+    position: dragState.initialIndex,
+    state: dragState,
+  };
+
+  config.onDragstart(dragstartData);
 }
 
 export function handleNodePointerdown<T>(

--- a/tests/pages/synthetic-drag-events.vue
+++ b/tests/pages/synthetic-drag-events.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useDragAndDrop } from "../../src/vue/index";
+
+const dragstartCount = ref(0);
+const lastDragstartValue = ref("");
+
+const [parent, values] = useDragAndDrop(["Apple", "Banana", "Orange"], {
+  onDragstart: (event) => {
+    dragstartCount.value += 1;
+    lastDragstartValue.value = String(event.draggedNode.data.value);
+  },
+});
+</script>
+
+<template>
+  <div>
+    <ul ref="parent" class="list">
+      <li v-for="value in values" :id="value" :key="value" class="item">
+        {{ value }}
+      </li>
+    </ul>
+    <div id="dragstart_count">{{ dragstartCount }}</div>
+    <div id="dragstart_value">{{ lastDragstartValue }}</div>
+  </div>
+</template>
+
+<style scoped>
+.list {
+  list-style-type: none;
+  padding: 0;
+}
+
+.item {
+  padding: 10px;
+  margin: 5px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+</style>


### PR DESCRIPTION
#204

## What Changed
- Added `onDragstart` emission to the synthetic drag start path so touch/pointer-based synthetic drags trigger the same callback as native drags.
- Refactored dragstart event payload creation into a shared helper to keep native and synthetic behavior consistent.
- Added a Playwright synthetic-drag test that verifies:
  - the callback fires when synthetic drag starts
  - the dragged value in the callback matches the expected item